### PR TITLE
FIX pointless "or" in login/register UI without external auth

### DIFF
--- a/src/app/account/components/login/login-dialog.component.html
+++ b/src/app/account/components/login/login-dialog.component.html
@@ -82,7 +82,7 @@
 
             </a>
           </div>
-          <div translate="COMPONENTS.LOGIN_FORM.LOGIN_OR"></div>
+          <div translate="COMPONENTS.LOGIN_FORM.LOGIN_OR" *ngIf="authMethodsAvailable.esteid || authMethodsAvailable.smartId || authMethodsAvailable.google || authMethodsAvailable.facebook"></div>
           <login-form [isDialog]="true" [redirectSuccess]="redirectSuccess" [email]="email"></login-form>
         </div>
       </ng-container>

--- a/src/app/account/components/login/login.component.html
+++ b/src/app/account/components/login/login.component.html
@@ -65,7 +65,7 @@
 
       </a>
     </div>
-    <div translate="COMPONENTS.LOGIN_FORM.LOGIN_OR"></div>
+    <div translate="COMPONENTS.LOGIN_FORM.LOGIN_OR" *ngIf="authMethodsAvailable.esteid || authMethodsAvailable.smartId || authMethodsAvailable.google || authMethodsAvailable.facebook"></div>
     <login-form [redirectSuccess]="redirectSuccess" [email]="email"></login-form>
   </div>
 </div>

--- a/src/app/account/components/register/register.component.html
+++ b/src/app/account/components/register/register.component.html
@@ -79,7 +79,7 @@
 
       </a>
     </div>
-    <div translate="VIEWS.REGISTER.REGISTER_OR"></div>
+    <div translate="VIEWS.REGISTER.REGISTER_OR" *ngIf="authMethodsAvailable.esteid || authMethodsAvailable.smartId || authMethodsAvailable.google || authMethodsAvailable.facebook"></div>
     <register-form [redirectSuccess]="redirectSuccess" [email]="email"></register-form>
   </div>
 </div>


### PR DESCRIPTION
Normally, these UIs show a list of external out icon, then the word "or" and then the builtin e-mail based authentication. However, when all external authentication providers are disabled, their icons are hidden, but the (now pointless and confusing) "or" stays. This commit fixes that.