### PR TITLE
Allow overriding authentication config using env vars

### DIFF
--- a/src/assets/config/custom-environment-variables.json
+++ b/src/assets/config/custom-environment-variables.json
@@ -31,6 +31,10 @@
     "analytics": {
       "__name": "CITIZENOS_FEATURES_ANALYTICS",
       "__format": "json"
+    },
+    "authentication": {
+      "__name": "CITIZENOS_FEATURES_AUTHENTICATION",
+      "__format": "json"
     }
   },
   "helplink": "CITIZENOS_HELP_LINK",


### PR DESCRIPTION
This makes it possible to e.g. disable external authentication using env vars.