### PR TITLE
FIX error message when prebuildDist.js fails to write

### DIFF
--- a/prebuildDist.js
+++ b/prebuildDist.js
@@ -15,6 +15,6 @@ try {
     settingsFileTxt += '}(this));';*/
     fs.writeFileSync(pathDistSettings, JSON.stringify(configFe));
 } catch (err) {
-    console.log('config.ts write FAILED to ' + pathSettings, err);
+    console.log('config.ts write FAILED to ' + pathDistSettings, err);
     process.exit(1);
 }


### PR DESCRIPTION
Before this commit, a write error in prebuildDist.js would lead to another error in the error handling code:

	/opt/citizenos/prebuildDist.js:18
	    console.log('config.ts write FAILED to ' + pathSettings, err);
						       ^

	ReferenceError: pathSettings is not defined
	    at Object.<anonymous> (/opt/citizenos/prebuildDist.js:18:48)

With this commit, the actual error message is displayed as intended:

	config.ts write FAILED to /.../browser/assets/config/config.json Error: ENOENT: no such file or directory, open '/.../browser/assets/config/config.json'
	    at Object.writeFileSync (node:fs:2344:20)
	    at Object.<anonymous> (/opt/citizenos/prebuildDist.js:16:8)