### PR TITLE
Fix ideas count when creating new folder

### DIFF
--- a/src/app/ideation/components/create-idea-folder/create-idea-folder.component.html
+++ b/src/app/ideation/components/create-idea-folder/create-idea-folder.component.html
@@ -50,7 +50,7 @@
                   <label class="checkbox" [ngClass]="{selected:allChecked()}">
                     <span class="checkmark"></span>
                   </label>
-                  <div translate="COMPONENTS.CREATE_IDEA_FOLDER.LBL_IDEAS" [translateParams]="{count: ideasCount}">
+                  <div translate="COMPONENTS.CREATE_IDEA_FOLDER.LBL_IDEAS" [translateParams]="{count: ideas.length}">
                   </div>
                 </div>
                 <div class="likes_wrap">


### PR DESCRIPTION
Steps to test:
- go to any topic with ideas or create one
- select "Folders" tab
- press "Create new folder"

Current:
- shows "Ideas (0)"

Expected:
- show "Ideas ({count})"