### PR TITLE
Fix folders disappear on close button click when creating new folder

### DIFF
--- a/src/app/ideation/components/create-idea-folder/create-idea-folder.component.ts
+++ b/src/app/ideation/components/create-idea-folder/create-idea-folder.component.ts
@@ -1,7 +1,7 @@
 import { TopicIdeaService } from '@services/topic-idea.service';
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
-import { Observable, Subscription, map, of, take, combineLatest, switchMap, tap } from 'rxjs';
+import { map, take } from 'rxjs';
 import { Idea } from 'src/app/interfaces/idea';
 import { DIALOG_DATA, DialogRef } from 'src/app/shared/dialog';
 import { TopicIdeationFoldersService } from '@services/topic-ideation-folders.service';
@@ -26,24 +26,12 @@ export class CreateIdeaFolderComponent {
   constructor(public TopicIdeaService: TopicIdeaService, public TopicIdeationFoldersService: TopicIdeationFoldersService, @Inject(DIALOG_DATA) data: any, private dialogRef: DialogRef<CreateIdeaFolderComponent>) {
     this.topicId = data.topicId;
     this.ideationId = data.ideationId;
-    let offset = 0;
-    let limit = 8;
-    this.TopicIdeaService.setParam('topicId', data.topicId);
-    this.TopicIdeaService.setParam('ideationId', data.ideationId);
-    this.TopicIdeaService.setParam('offset', offset);
-    this.TopicIdeaService.setParam('limit', limit);
+    this.TopicIdeaService.page$.next(1);
     this.ideas$ = this.TopicIdeaService.loadItems().pipe(
-      tap((res: any) => {
-        if (res.length) {
-          this.TopicIdeaService.hasMore$.next(true);
-        } else {
-          this.TopicIdeaService.hasMore$.next(false);
-        }
-      }),
       map(
         (newIdeas: any) => {
           this.allIdeas$ = this.allIdeas$.concat(newIdeas);
-          if (this.allIdeas$.length < 10 && newIdeas.length) {
+          if (newIdeas.length > 0) {
             this.TopicIdeaService.loadMore();
           }
           return this.allIdeas$;
@@ -53,14 +41,11 @@ export class CreateIdeaFolderComponent {
   createFolder() {
     this.TopicIdeationFoldersService.save({ topicId: this.topicId, ideationId: this.ideationId }, this.form.value).pipe(take(1)).subscribe({
       next: (folder) => {
-        console.log('RES', folder);
         if (this.folderIdeas.length) {
           this.TopicIdeationFoldersService.addIdea({ topicId: this.topicId, ideationId: this.ideationId, folderId: folder.id }, this.folderIdeas)
             .pipe(take(1))
             .subscribe({
               next: (res) => {
-                console.log('IDEAS to folder', res)
-
                 this.dialogRef.close();
               },
               error: (err) => {
@@ -85,10 +70,8 @@ export class CreateIdeaFolderComponent {
   }
 
   toggleIdea(idea: Idea, $event: any) {
-    console.log('toggle', $event);
     $event.stopPropagation();
     const index = this.folderIdeas.findIndex((item) => item.id === idea.id);
-    console.log('index', index);
     if (index === -1) {
       this.folderIdeas.push(idea);
     } else {

--- a/src/app/ideation/components/topic-ideation/topic-ideation.component.ts
+++ b/src/app/ideation/components/topic-ideation/topic-ideation.component.ts
@@ -85,14 +85,14 @@ export class TopicIdeationComponent {
   ) { }
 
   ngOnInit(): void {
-
     this.ideas$ = combineLatest([this.ideaTypeFilter$, this.orderFilter$, this.ideaParticipantsFilter$, this.folderFilter$, this.ideaSearchFilter$, this.TopicIdeaService.reload$])
       .pipe(
         switchMap(([typeFilter, orderFilter, participantFilter, folderFilter, search, load]) => {
-          this.TopicIdeaService.setParam('topicId', this.topic.id);
           this.TopicIdeaService.reset();
           this.TopicIdeaService.setParam('topicId', this.topic.id);
           this.TopicIdeaService.setParam('ideationId', this.topic.ideationId);
+          this.TopicIdeaService.setParam('offset', 0);
+          this.TopicIdeaService.setParam('limit', 15);
           this.allIdeas$ = [];
           if (typeFilter) {
             if (['favourite', 'showModerated'].indexOf(typeFilter) > -1) {
@@ -379,6 +379,7 @@ export class TopicIdeationComponent {
 
     folderCreateDialog.afterClosed().subscribe(() => {
       this.loadFolders$.next();
+      this.TopicIdeaService.page$.next(1);
     });
   };
 


### PR DESCRIPTION
Steps to reproduce:
- go to topic
- create some ideas if not there are no
- go to Folders/Create new folder
- close popup

Current: 
- Ideas/Folders tabs disappears

Expected:
- Ideas/Folders tabs work as expected
---
Additional issues:
As `TopicIdeaService` operates data for both `TopicIdeationComponent/CreateIdeaFolderComponent`, 2 components mix their data and some unexpected issues happen:
- go to topic
- add 20-30 ideas (for 2-4 pages for example)
- go to Folders/Create new folder
- close popup
- go back to Ideas

Current:
- initial page count changes from 15 to 8
- doing that many times increases page counter inside `TopicIdeaService` and influence both page items and create folder popup

Expected:
- everything should work as expected

Solution:
- move `setParams` to `TopicIdeationComponent`
- reset page when open/close create folder popup (not the best idea, but more complex refactoring needed)
- as `TopicIdeaService` operates data for both `TopicIdeationComponent/CreateIdeaFolderComponent`, set limit for ideas page to 15 for both TopicIdeationComponent and CreateIdeaFolderComponent to avoid extra complexity
