### PR TITLE
Update redirect to the group in global search

### DIFF
--- a/src/app/core/components/search/search.component.ts
+++ b/src/app/core/components/search/search.component.ts
@@ -138,9 +138,6 @@ export class SearchComponent implements OnInit {
         return this.router.navigate(['/topics', item.id]);
       } else if (model === 'group' && item.id) {
         this.app.showSearch = false;
-        if (this.AuthService.loggedIn$.value === true && context === 'my') {
-          return this.router.navigate(['my/groups', item.id], { queryParams: { filter: 'grouped' } });
-        }
         return this.router.navigate(['/groups', item.id]);
       }
     }


### PR DESCRIPTION
Steps to test:
- start global search
- search for some group

Current:
- goes to /my/groups

Expected:
- go to chosen group view