### PR TITLE
#1782

### DIFF
--- a/src/app/my-groups/my-groups.component.html
+++ b/src/app/my-groups/my-groups.component.html
@@ -17,257 +17,37 @@
   </div>
   <div id="page_filters_wrap">
     <div id="options_area" [@openClose]="moreFilters ? 'open' : 'closed'" class="mobile_hidden">
-      <div class="options_row">
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_VISIBILITY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!groupFilters.visibility" translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-                <span *ngIf="groupFilters.visibility" translate="VIEWS.MY_GROUPS.FILTER_FAVOURITED"></span>
+      <div class="options_row" [ngClass]="moreFilters? 'open' : 'closed'">
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <cos-input [placeholder]="filtersData[filterKey].placeholder| translate" class="dropdown_input">
+            <div class="dropdown" [cosDropdown]>
+              <div class="selection">
+                <div class="selected_item">
+                  <ng-container [ngSwitch]="filterKey">
+                    <span *ngSwitchCase="'visibility'">{{ getActiveFilterText("visibility", filtersData.visibility.selectedValue) | uppercase | translate | titlecase }}</span>
+                    <span *ngSwitchDefault>{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+                  </ng-container>
+                </div>
+                <div>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
+                  </svg>
+                </div>
               </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
+              <div class="options">
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <div class="option" (click)="setFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'visibility'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                  </div>
+                </ng-container>
               </div>
             </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_GROUPS.FILTER_ALL" (click)="setVisibility('');"></div>
-              <div class="option" *ngFor="let item of visibility" (click)="setVisibility(item)">
-                {{'TXT_GROUP_VISIBILITY_' + item | uppercase | translate | titlecase}}
-              </div>
-              <div class="option" (click)="setVisibility('favourite')" translate="VIEWS.MY_GROUPS.FILTER_FAVOURITED">
-              </div>
-              <!--div class="option" [routerLink]="['./']" [queryParams]="{moderated: 'true'}"
-                translate="VIEWS.MY_GROUPS.FILTER_MODERATED"></!--div-->
-            </div>
-          </div>
-        </cos-input>
+          </cos-input>
+        </ng-container>
 
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_MY_ENGAGEMENT' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span translate="VIEWS.MY_GROUPS.FILTER_ALL"
-                  *ngIf="!groupFilters.engagements || (groupFilters.engagements === 'all')"></span>
-                <span translate="VIEWS.MY_GROUPS.FILTER_GROUPS_I_CREATED"
-                  *ngIf="groupFilters.engagements === 'iCreated'"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_GROUPS.FILTER_ALL" (click)="setFilter('');">
-              </div>
-              <div class="option" translate="VIEWS.MY_GROUPS.FILTER_GROUPS_I_CREATED" (click)="setFilter('iCreated')">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_ORDER' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!groupFilters.orderBy" translate="VIEWS.MY_GROUPS.ORDER_ALL"></span>
-                <span *ngIf="groupFilters.orderBy === 'activity'"
-                  translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY"></span>
-                <span *ngIf="groupFilters.orderBy === 'activityCount'"
-                  translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES"></span>
-                <span *ngIf="groupFilters.orderBy === 'memberCount'"
-                  translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS"></span>
-                <span *ngIf="groupFilters.orderBy === 'createdAt'" translate="VIEWS.MY_GROUPS.MOST_RECENT"></span>
-                <span *ngIf="groupFilters.orderBy === 'topicCount'" translate="VIEWS.MY_GROUPS.MOST_TOPICS"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_GROUPS.FILTER_ALL" (click)="orderBy('')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY" (click)="orderBy('activity')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES" (click)="orderBy('activityCount')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS" (click)="orderBy('memberCount')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_RECENT" (click)="orderBy('createdAt')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_TOPICS" (click)="orderBy('topicCount')"></div>
-            </div>
-          </div>
-        </cos-input>
-        <!--cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_MY_ENGAGEMENT' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option">My most recent activity</div>
-              <div class="option">Groups I created</div>
-              <div class="option">Groups with pending requests</div>
-            </div>
-          </div>
-        </!--cos-input-->
-      </div>
-      <div class="options_row tablet_show" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_ORDER' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!groupFilters.orderBy" translate="VIEWS.MY_GROUPS.ORDER_ALL"></span>
-                <span *ngIf="groupFilters.orderBy === 'activity'"
-                  translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY"></span>
-                <span *ngIf="groupFilters.orderBy === 'activityCount'"
-                  translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES"></span>
-                <span *ngIf="groupFilters.orderBy === 'memberCount'"
-                  translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS"></span>
-                <span *ngIf="groupFilters.orderBy === 'createdAt'" translate="VIEWS.MY_GROUPS.MOST_RECENT"></span>
-                <span *ngIf="groupFilters.orderBy === 'topicCount'" translate="VIEWS.MY_GROUPS.MOST_TOPICS"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_GROUPS.FILTER_ALL" (click)="orderBy('')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY" (click)="orderBy('activity')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES" (click)="orderBy('activityCount')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS" (click)="orderBy('memberCount')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_RECENT" (click)="orderBy('createdAt')"></div>
-              <div class="option" translate="VIEWS.MY_GROUPS.MOST_TOPICS" (click)="orderBy('topicCount')"></div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.country)? groupFilters.country : 'VIEWS.MY_GROUPS.FILTER_ALL' |
-                translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_LANGUAGE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.language)? groupFilters.language : 'VIEWS.MY_GROUPS.FILTER_ALL'
-                | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <!--div class="options_row" *ngIf="moreFilters">
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_CATEGORIES' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" *ngFor="let item of categories">
-                {{item}}
-              </div>
-            </div>
-          </div>
-        </!--cos-input-->
-
-      <!--cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{'VIEWS.MY_GROUPS.ORDER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </!--cos-input--
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_LANGUAGE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{'VIEWS.MY_GROUPS.ORDER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-
-      </div-->
-      <div class="options_row" *ngIf="moreFilters">
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_COUNTRY' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.country)? groupFilters.country : 'VIEWS.MY_GROUPS.FILTER_ALL' |
-                translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_GROUPS.FILTER_LANGUAGE' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.language)? groupFilters.language : 'VIEWS.MY_GROUPS.FILTER_ALL'
-                | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
         <div class="input_area">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -314,47 +94,15 @@
       </div>
 
       <div class="options filter_options">
-        <a class="filter_option" (click)="mobileFilters.visibility = true">
-          <span class="filter_option_text" translate="VIEWS.MY_GROUPS.FILTER_VISIBILITY"></span>
-          <span class="bold">
-            <span *ngIf="!groupFilters.visibility" translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-            <span *ngIf="groupFilters.visibility" translate="VIEWS.MY_GROUPS.FILTER_FAVOURITED"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.engagements = true">
-          <span class="filter_option_text" translate="VIEWS.MY_GROUPS.FILTER_MY_ENGAGEMENT"></span>
-          <span class="bold">
-            <span translate="VIEWS.MY_GROUPS.FILTER_ALL"
-              *ngIf="!groupFilters.engagements || (groupFilters.engagements === 'all')"></span>
-            <span translate="VIEWS.MY_GROUPS.FILTER_GROUPS_I_CREATED"
-              *ngIf="groupFilters.engagements === 'iCreated'"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.orderBy = true">
-          <span class="filter_option_text" translate="VIEWS.MY_GROUPS.FILTER_ORDER"></span>
-          <span class="bold">
-            <span *ngIf="!groupFilters.orderBy" translate="VIEWS.MY_GROUPS.ORDER_ALL"></span>
-            <span *ngIf="groupFilters.orderBy === 'activity'" translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY"></span>
-            <span *ngIf="groupFilters.orderBy === 'activityCount'" translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES"></span>
-            <span *ngIf="groupFilters.orderBy === 'memberCount'" translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS"></span>
-            <span *ngIf="groupFilters.orderBy === 'createdAt'" translate="VIEWS.MY_GROUPS.MOST_RECENT"></span>
-            <span *ngIf="groupFilters.orderBy === 'topicCount'" translate="VIEWS.MY_GROUPS.MOST_TOPICS"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.country = true">
-          <span class="filter_option_text" translate="VIEWS.MY_GROUPS.FILTER_COUNTRY"></span>
-          <span class="bold">{{(groupFilters.country) || 'VIEWS.MY_GROUPS.FILTER_ALL' |
-            translate}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.language = true">
-          <span class="filter_option_text" translate="VIEWS.MY_GROUPS.FILTER_LANGUAGE"></span>
-          <span class="bold">{{groupFilters.language || 'VIEWS.MY_GROUPS.FILTER_ALL' |
-            translate}}</span>
-        </a>
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <a class="filter_option" (click)="filtersData[filterKey].isMobileOpen = true">
+            <span class="filter_option_text">{{ filtersData[filterKey].placeholder| translate }}</span>
+            <ng-container [ngSwitch]="filterKey">
+              <span *ngSwitchCase="'visibility'" class="bold">{{ getActiveFilterText("visibility", filtersData.visibility.selectedValue) | uppercase | translate | titlecase }}</span>
+              <span *ngSwitchDefault class="bold">{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+            </ng-container>
+          </a>
+        </ng-container>
 
         <button (click)="doClearFilters()" class="btn_medium_plain">
           <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -380,153 +128,91 @@
         </div>
       </div>
     </div>
-    <div class="overlay" *ngIf="showMobileOverlay()" (click)="closeMobileFilter()"></div>
-    <div class="mobile_filters_wrap" [ngClass]="{'active': showMobileOverlay()}">
-      <div class="options button_options" *ngIf="mobileFilters.visibility">
-        <label class="checkbox" (click)="mobileFilters.visibility = 'all'">
-          <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
 
-        <label class="checkbox" *ngFor="let item of visibility" (click)="mobileFilters.visibility = item">
-          <span [translate]="'TXT_GROUP_VISIBILITY_'+item | uppercase"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.visibility = 'favourite'">
-          <span [translate]="'VIEWS.MY_GROUPS.FILTER_FAVOURITED'"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
+    <div class="overlay" *ngIf="hasMobileOpen" (click)="closeMobileFilter()"></div>
 
-        <!--div class="option" (click)="mobileFilters.visibility = {moderated: 'true'}"
-          translate="VIEWS.MY_GROUPS.FILTER_MODERATED">
-        </!--div-->
-        <button class="btn_medium_secondary"
-          (click)="setVisibility(mobileFilters.visibility);mobileFilters.visibility= false;"
-          translate="BTN_APPLY"></button>
-      </div>
-      <!--div class="options button_options" *ngIf="mobileFilters.category">
-        <label class="checkbox">
-          <span translate="TXT_TOPIC_CATEGORY_ALL"></span>
-          <input type="radio" name="category">
-          <span class="checkmark"></span>
-        </label>
+    <div class="mobile_filters_wrap" [ngClass]="{'active': hasMobileOpen}">
+      <ng-container *ngFor="let filterKey of filterKeys">
+        <div class="options button_options" *ngIf="filtersData[filterKey].isMobileOpen">
+          <ng-container [ngSwitch]="filterKey">
+            <search-filter
+              *ngSwitchCase="'country'"
+              [term]="countrySearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate"
+              [search]="searchCountry.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <label class="checkbox" *ngFor="let category of categories">
-          <span [translate]="'TXT_TOPIC_CATEGORY_'+category | uppercase"></span>
-          <input type="radio" name="category">
-          <span class="checkmark"></span>
-        </label>
+            <search-filter
+              *ngSwitchCase="'language'"
+              [term]="languageSearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate"
+              [search]="searchLanguage.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <button class="btn_medium_secondary" (click)="mobileFilters.category= false;">Apply</button>
-      </!--div-->
-      <div class="options button_options" *ngIf="mobileFilters.engagements">
-        <label class="checkbox" (click)="mobileFilters.engagements = 'all'">
-          <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-
-        <label class="checkbox" (click)="mobileFilters.engagements = 'iCreated'">
-          <span translate="VIEWS.MY_GROUPS.FILTER_GROUPS_I_CREATED"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-
-        <button class="btn_medium_secondary"
-          (click)="setFilter(mobileFilters.engagements); mobileFilters.engagements = false;"
-          translate="BTN_APPLY"></button>
-      </div>
-
-      <div class="options button_options" *ngIf="mobileFilters.orderBy">
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'all'">
-          <span translate="VIEWS.MY_GROUPS.ORDER_ALL"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'activity'">
-          <span translate="VIEWS.MY_GROUPS.ORDER_RECENT_ACTIVITY"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'activityCount'">
-          <span translate="VIEWS.MY_GROUPS.MOST_ACTIVITIES"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'memberCount'">
-          <span translate="VIEWS.MY_GROUPS.MOST_PARTICIPANTS"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'createdAt'">
-          <span translate="VIEWS.MY_GROUPS.MOST_RECENT"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'topicCount'">
-          <span translate="VIEWS.MY_GROUPS.MOST_TOPICS"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="orderBy(mobileFilters.orderBy); mobileFilters.orderBy = false;"
-          translate="BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.country">
-        <search-filter
-          [term]="countrySearch"
-          [placeholder]="'VIEWS.MY_GROUPS.FILTER_COUNTRY' | translate"
-          [search]="searchCountry.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
-
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.country = 'all'">
-            <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-            <input type="radio" name="country">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="countries$ | async as countries">
-            <label class="checkbox" *ngFor="let country of countries" (click)="mobileFilters.country = country.name;">
-              <span>{{country.name}}</span>
-              <input type="radio" name="country">
-              <span class="checkmark"></span>
-            </label>
+            <a *ngSwitchDefault class="btn_medium_close icon" (click)="closeMobileFilter()">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289Z"
+                  fill="#2C3B47" />
+              </svg>
+            </a>
           </ng-container>
-        </div>
-        <button class="btn_medium_secondary"
-          (click)="setCountry(mobileFilters.country.trim()); closeMobileFilter();"
-          translate="BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.language">
-        <search-filter
-          [term]="languageSearch"
-          [placeholder]="'VIEWS.MY_GROUPS.FILTER_LANGUAGE' | translate"
-          [search]="searchLanguage.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
 
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.language = 'all'">
-            <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-            <input type="radio" name="language">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="languages$ | async as languages">
-            <label class="checkbox" *ngFor="let language of languages" (click)="mobileFilters.language = language.name;">
-              <span>{{language.name}}</span>
-              <input type="radio" name="language">
-              <span class="checkmark"></span>
-            </label>
-          </ng-container>
-        </div>
+          <div class="options_wrapper">
+            <ng-container [ngSwitch]="filterKey">
+              <ng-container *ngSwitchCase="'country'">
+                <label class="checkbox" (click)="filtersData.country.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
+                  <input type="radio" name="country">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="countries$ | async as countries">
+                  <label class="checkbox" *ngFor="let country of countries" (click)="filtersData.country.preSelectedValue = country.name;">
+                    <span>{{country.name}}</span>
+                    <input type="radio" name="country">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
 
-        <button class="btn_medium_secondary"
-          (click)="setLanguage(mobileFilters.language.trim()); closeMobileFilter();"
-          translate="BTN_APPLY"></button>
-      </div>
+              <ng-container *ngSwitchCase="'language'">
+                <label class="checkbox" (click)="filtersData.language.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
+                  <input type="radio" name="language">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="languages$ | async as languages">
+                  <label class="checkbox" *ngFor="let language of languages" (click)="filtersData.language.preSelectedValue = language.name;">
+                    <span>{{language.name}}</span>
+                    <input type="radio" name="language">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchDefault>
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <label class="checkbox" (click)="chooseFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'visibility'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                    <input type="radio" name="{{filterKey}}">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+            </ng-container>
+          </div>
+  
+          <button class="btn_medium_secondary" (click)="setFilterValue(filterKey, filtersData[filterKey].preSelectedValue); closeMobileFilter();"
+            translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
+        </div>
+      </ng-container>
     </div>
   </div>
   <div class="groups_content">

--- a/src/app/my-groups/my-groups.component.scss
+++ b/src/app/my-groups/my-groups.component.scss
@@ -48,17 +48,46 @@
 
     .options_row {
       display: flex;
+      flex-wrap: wrap;
       gap: 16px;
       width: 100%;
       position: relative;
 
+      @include mixins.desktop {
+        &.open {
+          .dropdown_input:nth-of-type(n+4), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+4),
+          .input_area {
+            display: none;
+          }
+        }
+      }
+
       @include mixins.tablet {
-        flex-flow: row wrap;
+        &.open {
+          .dropdown_input:nth-of-type(n+3), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+3),
+          .input_area {
+            display: none;
+          }
+        }
       }
 
       .dropdown_input {
         flex-grow: 1;
-        min-width: calc(25% - 12px);
+        min-width: calc(100% / 3 - 12px);
 
         @include mixins.tablet {
           min-width: calc(50% - 12px);
@@ -145,14 +174,5 @@
 
   @include mixins.tablet {
     background-color: rgba(44, 59, 71, 0.8);
-  }
-}
-
-.dropdown {
-  @include mixins.dropdown-style;
-  min-width: 160px;
-
-  @include mixins.mobile {
-    width: calc(100% - 40px);
   }
 }

--- a/src/app/my-groups/my-groups.component.ts
+++ b/src/app/my-groups/my-groups.component.ts
@@ -269,15 +269,6 @@ export class MyGroupsComponent implements OnInit {
     this.showCreate = !this.showCreate;
   }
 
-  showMobileOverlay () {
-    const filtersShow = Object.entries(this.mobileFilters).find(([key, value]) => {
-      return !!value;
-    })
-    if (filtersShow) return true;
-
-    return false;
-  }
-
   closeMobileFilter() {
     const keys = this.filterKeys;
 

--- a/src/app/my-groups/my-groups.component.ts
+++ b/src/app/my-groups/my-groups.component.ts
@@ -35,7 +35,6 @@ export class MyGroupsComponent implements OnInit {
   showCreate = false;
   groups$: Observable<Group[] | any[]> = of([]);
   allGroups$: Group[] = [];
-  visibility = Object.values(this.GroupService.VISIBILITY);
   countrySearch = '';
   countrySearch$ = new BehaviorSubject('');
   countries = countries.sort((a: any, b: any) => {
@@ -56,25 +55,8 @@ export class MyGroupsComponent implements OnInit {
   searchInput = '';
   searchString$ = new BehaviorSubject('');
   moreFilters = false;
-  mobileFilters:any = {
-    visibility: false,
-    engagements: false,
-    category: false,
-    order: false,
-    country: false,
-    language: false
-  }
   mobileFiltersList = false;
   filtersSet = false;
-
-  groupFilters = {
-    visibility: '',
-    engagements: '',
-    category: '',
-    orderBy: '',
-    country: '',
-    language: ''
-  };
 
   visibilityFilter$ = new BehaviorSubject('');
   engagmentsFilter$ = new BehaviorSubject('');

--- a/src/app/my-topics/my-topics.component.html
+++ b/src/app/my-topics/my-topics.component.html
@@ -14,258 +14,43 @@
       <activities-button *ngIf="auth.loggedIn$ | async"></activities-button>
     </div>
   </div>
+
   <div id="page_filters_wrap">
     <div id="options_area" [@openClose]="moreFilters ? 'open' : 'closed'" class="mobile_hidden">
-      <div class="options_row" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_TOPIC_TYPE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!topicFilters.visibility" translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-                <span *ngIf="topicFilters.visibility === 'public'"
-                  translate="VIEWS.MY_TOPICS.FILTERS.MY_PUBLIC_TOPICS"></span>
-                <span *ngIf="topicFilters.visibility === 'private'"
-                  translate="VIEWS.MY_TOPICS.FILTERS.MY_PRIVATE_TOPICS"></span>
-                <span *ngIf="topicFilters.visibility === 'favourite'"> {{'VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED' |
-                  translate}}</span>
-                <span *ngIf="topicFilters.visibility === 'showModerated'"> {{'VIEWS.MY_TOPICS.FILTERS.TOPICS_MODERATED'
-                  |
-                  translate}}</span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTER_ALL" (click)="setVisibility('');">
-              </div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.MY_PUBLIC_TOPICS"
-                (click)="setVisibility(Topic.VISIBILITY.public)">
-              </div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.MY_PRIVATE_TOPICS"
-                (click)="setVisibility(Topic.VISIBILITY.private)">
-              </div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_MODERATED"
-                (click)="setVisibility('showModerated');"></div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED"
-                (click)="setVisibility('favourite');">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_MY_ENGAGEMENT' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span translate="VIEWS.MY_TOPICS.FILTER_ALL"
-                  *ngIf="!topicFilters.engagements || (topicFilters.engagements === 'all')"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED"
-                  *ngIf="topicFilters.engagements === 'hasVoted'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED"
-                  *ngIf="topicFilters.engagements === 'hasNotVoted'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED"
-                  *ngIf="topicFilters.engagements === 'iCreated'"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTER_ALL" (click)="setFilter('');">
-              </div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED"
-                (click)="setFilter('hasVoted')"></div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED"
-                (click)="setFilter('hasNotVoted')"></div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED" (click)="setFilter('iCreated')">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_STATUS' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown] [multipleChoice]="true">
-            <div class="selection">
-              <div class="selected_item"
-                [innerHtml]="'TXT_TOPIC_STATUS_' + (topicFilters.status || 'all') | uppercase | translate | titlecase">
+      <div class="options_row" [@openClose]="moreFilters ? 'open' : 'closed'" [ngClass]="moreFilters? 'open' : 'closed'">
 
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <cos-input [placeholder]="filtersData[filterKey].placeholder| translate" class="dropdown_input">
+            <div class="dropdown" [cosDropdown]>
+              <div class="selection">
+                <div class="selected_item">
+                  <ng-container [ngSwitch]="filterKey">
+                    <span *ngSwitchCase="'status'">{{ getActiveFilterText("status", filtersData.status.selectedValue) | uppercase | translate | titlecase }}</span>
+                    <span *ngSwitchCase="'category'">{{ getActiveFilterText("category", filtersData.category.selectedValue) | uppercase | translate }}</span>
+                    <span *ngSwitchDefault>{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+                  </ng-container>
+                </div>
+                <div>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
+                  </svg>
+                </div>
               </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option check">
-                <label class="checkbox">
-                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-                  <input type="checkbox" [checked]="!topicFilters.status" (click)="setStatus('');">
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-              <div class="option check" *ngFor="let status of statuses$">
-                <label class="checkbox">
-                  <span [innerHtml]="'TXT_TOPIC_STATUS_' + status | uppercase | translate | titlecase"></span>
-                  <input type="checkbox" [checked]="topicFilters.status === status" (click)="setStatus(status);">
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_ORDER' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span translate="VIEWS.MY_TOPICS.FILTER_ALL" *ngIf="!topicFilters.orderBy"></span>
-                <!--span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_RECENT_ACTIVITY"
-                  *ngIf="topicFilters.orderBy === 'activityTime'"></!--span>
-                <span-- translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_ACTIVITIES"
-                  *ngIf="topicFilters.orderBy === 'activityCount'"></span-->
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"
-                  *ngIf="topicFilters.orderBy === 'membersCount'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT"
-                  *ngIf="topicFilters.orderBy === 'created'"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
+              <div class="options">
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <div class="option" (click)="setFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'status'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchCase="'category'">{{ option.title | uppercase | translate }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                  </div>
+                </ng-container>
               </div>
             </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTER_ALL" (click)="orderBy('')"></div>
-              <!--div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_RECENT_ACTIVITY"
-                (click)="orderBy('activityTime')"></!--div>
-              <div-- class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_ACTIVITIES"
-                (click)="orderBy('activityCount')"></div-->
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"
-                (click)="orderBy('membersCount')"></div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT" (click)="orderBy('created')">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <div class="options_row tablet_show" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_STATUS' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown] [multipleChoice]="true">
-            <div class="selection">
-              <div class="selected_item"
-                [innerHtml]="'TXT_TOPIC_STATUS_' + (topicFilters.status || 'all') | uppercase | translate | titlecase">
+          </cos-input>
+        </ng-container>
 
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option check">
-                <label class="checkbox">
-                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-                  <input type="checkbox" [checked]="!topicFilters.status" (click)="setStatus('');">
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-              <div class="option check" *ngFor="let status of statuses$">
-                <label class="checkbox">
-                  <span [innerHtml]="'TXT_TOPIC_STATUS_' + status | uppercase | translate | titlecase"></span>
-                  <input type="checkbox" [checked]="topicFilters.status === status" (click)="setStatus(status);">
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_ORDER' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span translate="VIEWS.MY_TOPICS.FILTER_ALL" *ngIf="!topicFilters.orderBy"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_RECENT_ACTIVITY"
-                  *ngIf="topicFilters.orderBy === 'activityTime'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_ACTIVITIES"
-                  *ngIf="topicFilters.orderBy === 'activityCount'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"
-                  *ngIf="topicFilters.orderBy === 'membersCount'"></span>
-                <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT"
-                  *ngIf="topicFilters.orderBy === 'created'"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTER_ALL" (click)="orderBy('')"></div>
-              <!--div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_RECENT_ACTIVITY"
-                (click)="orderBy('activityTime')"></!--div>
-              <div-- class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_ACTIVITIES"
-                (click)="orderBy('activityCount')"></div-->
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"
-                (click)="orderBy('membersCount')"></div>
-              <div class="option" translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT" (click)="orderBy('created')">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <div class="options_row" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_CATEGORIES' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{'TXT_TOPIC_CATEGORY_'+(topicFilters.category || 'all') | uppercase |
-                translate | titlecase}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCategory('');" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let category of categories$" (click)="setCategory(category);">
-                {{'TXT_TOPIC_CATEGORY_' + category | uppercase | translate}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(topicFilters.country)?
-                this.topicFilters.country : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="VIEWS.MY_TOPICS.FILTER_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(topicFilters.language && topicFilters.language !== 'all')?
-                topicFilters.language : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="VIEWS.MY_TOPICS.FILTER_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
         <div class="input_area">
           <div>
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -283,6 +68,7 @@
         </div>
       </div>
     </div>
+
     <div class="filter_control_buttons mobile_hidden">
       <button class="btn_big_secondary" [ngClass]="moreFilters? 'flip' : ''" (click)="moreFilters = !moreFilters">
         <div class="btn_icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"
@@ -313,70 +99,16 @@
         </button>
       </div>
       <div class="options filter_options">
-        <a class="filter_option" (click)="mobileFilters.type = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_TOPIC_TYPE"></span>
-          <span class="bold">
-            <span *ngIf="!topicFilters.visibility" translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-            <span *ngIf="topicFilters.visibility === 'public'"
-              translate="VIEWS.MY_TOPICS.FILTERS.MY_PUBLIC_TOPICS"></span>
-            <span *ngIf="topicFilters.visibility === 'private'"
-              translate="VIEWS.MY_TOPICS.FILTERS.MY_PRIVATE_TOPICS"></span>
-            <span *ngIf="topicFilters.visibility === 'favourite'"> {{'VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED' |
-              translate}}</span>
-            <span *ngIf="topicFilters.visibility === 'showModerated'"> {{'VIEWS.MY_TOPICS.FILTERS.TOPICS_MODERATED' |
-              translate}}</span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.engagements = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_MY_ENGAGEMENT"></span>
-          <span class="bold">
-            <span translate="VIEWS.MY_TOPICS.FILTER_ALL" *ngIf="!topicFilters.engagements"></span>
-            <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED"
-              *ngIf="topicFilters.engagements === 'hasVoted'"></span>
-            <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED"
-              *ngIf="topicFilters.engagements === 'hasNotVoted'"></span>
-            <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED"
-              *ngIf="topicFilters.engagements === 'iCreated'"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.status = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_STATUS"></span>
-          <span class="bold"
-            [innerHtml]="'TXT_TOPIC_STATUS_' + (topicFilters.status || 'all') | uppercase | translate | titlecase">
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.orderBy = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_ORDER"></span>
-          <span class="bold">
-            <span translate="VIEWS.MY_TOPICS.FILTER_ALL" *ngIf="!topicFilters.orderBy"></span>
-            <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"
-              *ngIf="topicFilters.orderBy === 'membersCount'"></span>
-            <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT"
-              *ngIf="topicFilters.orderBy === 'created'"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.category = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_CATEGORIES"></span>
-          <span class="bold">{{(topicFilters.category)?
-            topicFilters.category : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.country = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_COUNTRY"></span>
-          <span class="bold">{{(topicFilters.country)?
-            topicFilters.country : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.language = true">
-          <span class="filter_option_text" translate="VIEWS.MY_TOPICS.FILTER_LANGUAGE"></span>
-          <span class="bold">
-            {{(topicFilters.language && topicFilters.language !== 'all')?
-            topicFilters.language : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</span>
-        </a>
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <a class="filter_option" (click)="filtersData[filterKey].isMobileOpen= true">
+            <span class="filter_option_text">{{ filtersData[filterKey].placeholder| translate }}</span>
+            <ng-container [ngSwitch]="filterKey">
+              <span *ngSwitchCase="'status'" class="bold">{{ getActiveFilterText("status", filtersData.status.selectedValue) | uppercase | translate | titlecase }}</span>
+              <span *ngSwitchCase="'category'" class="bold">{{ getActiveFilterText("category", filtersData.category.selectedValue) | uppercase | translate }}</span>
+              <span *ngSwitchDefault class="bold">{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+            </ng-container>
+          </a>
+        </ng-container>
 
         <button (click)="doClearFilters()" class="btn_medium_plain">
           <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -403,186 +135,94 @@
       </div>
     </div>
 
-    <div class="overlay" *ngIf="showMobileOverlay()" (click)="closeMobileFilter()"></div>
-    <div class="mobile_filters_wrap" [ngClass]="{'active': showMobileOverlay()}">
-      <div class="options button_options" *ngIf="mobileFilters.type">
-        <label class="checkbox" (click)="mobileFilters.type = 'all';">
-          <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.type = Topic.VISIBILITY.public;">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.MY_PUBLIC_TOPICS"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.type = Topic.VISIBILITY.private;">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.MY_PRIVATE_TOPICS"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.type = 'showModerated'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_MODERATED"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.type = 'favourite'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="setVisibility(mobileFilters.type);mobileFilters.type= false;"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.status">
-        <label class="checkbox" (click)="mobileFilters.status = 'all';">
-          <span [innerHtml]="'TXT_TOPIC_STATUS_ALL' | translate | titlecase"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
+    <div class="overlay" *ngIf="hasMobileOpen" (click)="closeMobileFilter()"></div>
 
-        <label class="checkbox" *ngFor="let status of statuses$" (click)="mobileFilters.status = status">
-          <span [innerHtml]="'TXT_TOPIC_STATUS_' + status | uppercase | translate | titlecase"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="setStatus(mobileFilters.status);mobileFilters.status= false;"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.engagements">
-        <label class="checkbox" (click)="mobileFilters.engagements = 'all';">
-          <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.engagements = 'hasVoted';">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.engagements = 'hasNotVoted';">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
+    <div class="mobile_filters_wrap" [ngClass]="{'active': hasMobileOpen}">
+      <ng-container *ngFor="let filterKey of filterKeys">
+        <div class="options button_options" *ngIf="filtersData[filterKey].isMobileOpen">
+          <ng-container [ngSwitch]="filterKey">
+            <search-filter
+              *ngSwitchCase="'country'"
+              [term]="countrySearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate"
+              [search]="searchCountry.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <label class="checkbox" (click)="mobileFilters.engagements = 'iCreated'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
+            <search-filter
+              *ngSwitchCase="'language'"
+              [term]="languageSearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate"
+              [search]="searchLanguage.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <button class="btn_medium_secondary"
-          (click)="setFilter(mobileFilters.engagements);mobileFilters.engagements = false;"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.orderBy">
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'all';">
-          <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <!--label class="checkbox" (click)="mobileFilters.orderBy = 'activityTime'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_RECENT_ACTIVITY"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </!--label>
-        <label-- class="checkbox" (click)="mobileFilters.orderBy = 'activityCount'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_ACTIVITIES"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label-->
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'membersCount'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'created'">
-          <span translate="VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT"></span>
-          <input type="radio" name="type">
-          <span class="checkmark"></span>
-        </label>
-
-        <button class="btn_medium_secondary" (click)="orderBy(mobileFilters.orderBy);mobileFilters.orderBy= false;"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.category">
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.category = ''">
-            <span translate="TXT_TOPIC_CATEGORY_ALL"></span>
-            <input type="radio" name="category">
-            <span class="checkmark"></span>
-          </label>
-
-          <label class="checkbox" *ngFor="let category of categories$" (click)=" mobileFilters.category = category">
-            <span [translate]="'TXT_TOPIC_CATEGORY_'+category | uppercase"></span>
-            <input type="radio" name="category">
-            <span class="checkmark"></span>
-          </label>
-        </div>
-
-        <button class="btn_medium_secondary"
-          (click)="setCategory(mobileFilters.category); closeMobileFilter();"
-          translate="COMPONENTS.PUBLIC_TOPICS.BTN_APPLY"></button>
-      </div>
-
-      <div class="options button_options" *ngIf="mobileFilters.country">
-        <search-filter
-          [term]="countrySearch"
-          [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate"
-          [search]="searchCountry.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.country = 'all'">
-            <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
-            <input type="radio" name="country">
-            <span class="checkmark"></span>
-          </label>
-
-          <ng-container *ngIf="countries$ | async as countries">
-            <label class="checkbox" *ngFor="let country of countries" (click)="mobileFilters.country = country.name;">
-              <span>{{country.name}}</span>
-              <input type="radio" name="country">
-              <span class="checkmark"></span>
-            </label>
+            <a *ngSwitchDefault class="btn_medium_close icon" (click)="closeMobileFilter()">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289Z"
+                  fill="#2C3B47" />
+              </svg>
+            </a>
           </ng-container>
+
+          <div class="options_wrapper">
+            <ng-container [ngSwitch]="filterKey">
+              <ng-container *ngSwitchCase="'country'">
+                <label class="checkbox" (click)="filtersData.country.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
+                  <input type="radio" name="country">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="countries$ | async as countries">
+                  <label class="checkbox" *ngFor="let country of countries" (click)="filtersData.country.preSelectedValue = country.name;">
+                    <span>{{country.name}}</span>
+                    <input type="radio" name="country">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchCase="'language'">
+                <label class="checkbox" (click)="filtersData.language.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
+                  <input type="radio" name="language">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="languages$ | async as languages">
+                  <label class="checkbox" *ngFor="let language of languages" (click)="filtersData.language.preSelectedValue = language.name;">
+                    <span>{{language.name}}</span>
+                    <input type="radio" name="language">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchDefault>
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <label class="checkbox" (click)="chooseFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'status'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchCase="'category'">{{ option.title | uppercase | translate }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                    <input type="radio" name="{{filterKey}}">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+            </ng-container>
+          </div>
+  
+          <button class="btn_medium_secondary" (click)="setFilterValue(filterKey, filtersData[filterKey].preSelectedValue); closeMobileFilter();"
+            translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
         </div>
-
-        <button class="btn_medium_secondary" (click)="setCountry(mobileFilters.country); closeMobileFilter();"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
-
-      <div class="options button_options" *ngIf="mobileFilters.language">
-        <search-filter
-          [term]="languageSearch"
-          [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate"
-          [search]="searchLanguage.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
-
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.language = 'all'">
-            <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
-            <input type="radio" name="language">
-            <span class="checkmark"></span>
-          </label>
-
-          <ng-container *ngIf="languages$ | async as languages">
-            <label class="checkbox" *ngFor="let language of languages" (click)="mobileFilters.language = language.name;">
-              <span>{{language.name}}</span>
-              <input type="radio" name="language">
-              <span class="checkmark"></span>
-            </label>
-          </ng-container>
-        </div>
-
-        <button class="btn_medium_secondary"
-          (click)="setLanguage(mobileFilters.language); closeMobileFilter();"
-          translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
-      </div>
+      </ng-container>
     </div>
   </div>
+
   <div class="topics_content">
     <ng-container *ngIf="topics$ | async as topics;">
       <ng-container *ngIf="!topics.length && !filtersSet">

--- a/src/app/my-topics/my-topics.component.scss
+++ b/src/app/my-topics/my-topics.component.scss
@@ -53,12 +53,41 @@
 
     .options_row {
       display: flex;
+      flex-wrap: wrap;
       gap: 16px;
       width: 100%;
       position: relative;
 
+      @include mixins.desktop {
+        &.open {
+          .dropdown_input:nth-of-type(n+5), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+5),
+          .input_area {
+            display: none;
+          }
+        }
+      }
+    
       @include mixins.tablet {
-        flex-flow: row wrap;
+        &.open {
+          .dropdown_input:nth-of-type(n+3), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+3),
+          .input_area {
+            display: none;
+          }
+        }
       }
 
       .dropdown_input {

--- a/src/app/my-topics/my-topics.component.ts
+++ b/src/app/my-topics/my-topics.component.ts
@@ -48,9 +48,7 @@ export class MyTopicsComponent {
 
   mobileFiltersList = false;
   showCreate = false;
-  categories$ = Object.keys(this.Topic.CATEGORIES);
 
-  statuses$ = Object.keys(this.Topic.STATUSES);
   countrySearch = '';
   countrySearch$ = new BehaviorSubject('');
   countries = countries.sort((a: any, b: any) => {

--- a/src/app/my-topics/my-topics.component.ts
+++ b/src/app/my-topics/my-topics.component.ts
@@ -19,7 +19,6 @@ import { Language } from '@interfaces/language';
   styleUrls: ['./my-topics.component.scss'],
   animations: [
     trigger('openClose', [
-      // ...
       state('open', style({
         'maxHeight': '300px',
         transition: '0.2s ease-in-out max-height'
@@ -38,15 +37,6 @@ export class MyTopicsComponent {
   topics$ = of(<Topic[] | any[]>[]);
 
   allTopics$: Topic[] = [];
-  topicFilters = {
-    visibility: '',
-    category: '',
-    status: '',
-    country: '',
-    orderBy: '',
-    engagements: '',
-    language: ''
-  };
 
   topicTypeFilter$ = new BehaviorSubject('');
   engagmentsFilter$ = new BehaviorSubject('');
@@ -55,16 +45,6 @@ export class MyTopicsComponent {
   categoryFilter$ = new BehaviorSubject('');
   countryFilter$ = new BehaviorSubject('');
   languageFilter$ = new BehaviorSubject('');
-
-  mobileFilters: any = {
-    type: false,
-    category: false,
-    status: false,
-    orderBy: false,
-    engagements: false,
-    country: false,
-    language: false,
-  }
 
   mobileFiltersList = false;
   showCreate = false;
@@ -86,6 +66,107 @@ export class MyTopicsComponent {
   languages$ = of(<Language[]>[]);
   filtersSet = false;
 
+  filtersData = {
+    visibility: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_TOPIC_TYPE",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'VIEWS.MY_TOPICS.FILTER_ALL', value: "all"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.MY_PUBLIC_TOPICS', value: this.Topic.VISIBILITY.public},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.MY_PRIVATE_TOPICS', value: this.Topic.VISIBILITY.private},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_MODERATED', value: "showModerated"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED', value: "favourite"},
+      ]
+    },
+    status: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_STATUS",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'TXT_TOPIC_STATUS_ALL', value: "all"},
+        ...Object.keys(this.Topic.STATUSES).map((status) => {
+          return { title: `TXT_TOPIC_STATUS_${status}`, value: status }
+        }),
+      ]
+    },
+    engagements: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_MY_ENGAGEMENT",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'VIEWS.MY_TOPICS.FILTER_ALL', value: "all"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED', value: "hasVoted"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED', value: "hasNotVoted"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED', value: "iCreated"},
+      ]
+    },
+    orderBy: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_ORDER",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'VIEWS.MY_TOPICS.FILTER_ALL', value: "all"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_PARTICIPANTS', value: "membersCount"},
+        { title: 'VIEWS.MY_TOPICS.FILTERS.ORDER_MOST_RECENT', value: "created"},
+      ]
+    },
+    category: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_CATEGORIES",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'TXT_TOPIC_CATEGORY_ALL', value: "all"},
+        ...Object.keys(this.Topic.CATEGORIES).map((cat) => {
+          return { title: `TXT_TOPIC_CATEGORY_${cat}`, value: cat }
+        }),
+      ]
+    },
+    country: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_COUNTRY",
+      selectedValue: "",
+      preSelectedValue: "",
+      /**
+       * @note Only for desktop. For mobile it looks for observable.
+       */
+      items: [
+        { title: 'VIEWS.MY_TOPICS.FILTER_ALL', value: "all"},
+        ...this.countries.map((it) => {
+          return { title: it.name, value: it.name }
+        }),
+      ]
+    },
+    language: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_LANGUAGE",
+      selectedValue: "",
+      preSelectedValue: "",
+      /**
+       * @note Only for desktop. For mobile it looks for observable.
+       */
+      items: [
+        { title: 'VIEWS.MY_GROUPS.FILTER_ALL', value: "all"},
+        ...this.languages.map((it) => {
+          return { title: it.name, value: it.name }
+        }),
+      ]
+    },
+  };
+
+  get filterKeys() {
+    return Object.keys(this.filtersData) as Array<keyof typeof this.filtersData>;
+  }
+
+  get hasMobileOpen() {
+    return Object.values(this.filtersData).some((filter) => filter.isMobileOpen);
+  }
+
   constructor(
     public Topic: TopicService,
     public UserTopicService: UserTopicService,
@@ -100,7 +181,6 @@ export class MyTopicsComponent {
       .pipe(
         switchMap(([topicTypeFilter, engagmentsFilter, statusFilter, orderFilter, categoryFilter, countryFilter, languageFilter, search]) => {
           UserTopicService.reset();
-       //   UserTopicService.setParam('include', ['vote', 'event']);
           this.allTopics$ = [];
           if (topicTypeFilter) {
             if (UserTopicService.VISIBILITY.indexOf(topicTypeFilter) > -1) {
@@ -172,29 +252,24 @@ export class MyTopicsComponent {
     this.showCreate = !this.showCreate;
   }
 
-  showMobileOverlay() {
-    const filtersShow = Object.entries(this.mobileFilters).find(([key, value]) => {
-      return !!value;
-    })
-    if (filtersShow) return true;
-
-    return false;
-  }
-
   closeMobileFilter() {
-    const filtersShow = Object.entries(this.mobileFilters).find(([key, value]) => {
-      return !!value;
+    const keys = this.filterKeys;
+
+    keys.forEach((key) => {
+      this.filtersData[key].isMobileOpen = false;
+      this.filtersData[key].preSelectedValue = "";
+      switch(key) {
+        case "language": {
+          this.languageSearch$.next(this.languageSearch);
+          break;
+        }
+        case "country": {
+          this.countrySearch$.next(this.countrySearch);
+          break;
+        }
+        default:
+      }
     })
-    if (filtersShow) {
-      const filterName = filtersShow[0]
-      this.mobileFilters[filterName] = false;
-      if (filterName === 'language') {
-        this.languageSearch$.next(this.languageSearch);
-      }
-      if (filterName === 'country') {
-        this.countrySearch$.next(this.countrySearch);
-      }
-    }
   }
 
   searchCountry(event: any) {
@@ -205,46 +280,43 @@ export class MyTopicsComponent {
     this.languageSearch$.next(event);
   }
 
-  orderBy(orderBy: string) {
-    if (orderBy === 'all' || typeof orderBy !== 'string') orderBy = '';
-    this.orderFilter$.next(orderBy);
-    this.topicFilters.orderBy = orderBy;
+  chooseFilterValue (type: keyof typeof this.filtersData, option: string) {
+    this.filtersData[type].preSelectedValue = option;
   }
 
-  setStatus(status: string) {
-    if (status === 'all' || typeof status !== 'string') status = '';
-    this.statusFilter$.next(status);
-    this.topicFilters.status = status;
+  setFilterValue(filter: keyof typeof this.filtersData, val: string) {
+    const value = val === 'all' ? '' : val;
+    switch (filter) {
+      case 'visibility':
+        this.topicTypeFilter$.next(value);
+        break;
+      case 'status':
+        this.statusFilter$.next(value);
+        break;
+      case 'orderBy':
+        this.orderFilter$.next(value);
+        break;
+      case 'engagements':
+        this.engagmentsFilter$.next(value);
+        break;
+      case 'category':
+        this.categoryFilter$.next(value);
+        break;
+      case 'country':
+        this.countryFilter$.next(value);
+        break;
+      case 'language':
+        this.languageFilter$.next(value);
+        break;
+      default:
+    }
+
+    this.filtersData[filter].selectedValue = value;
   }
 
-  setVisibility(visibility: string) {
-    if (visibility === 'all' || typeof visibility !== 'string') visibility = '';
-    this.topicTypeFilter$.next(visibility);
-    this.topicFilters.visibility = visibility;
-  }
-
-  setCategory(category: string) {
-    if (category === 'all' || typeof category !== 'string') category = '';
-    this.categoryFilter$.next(category);
-    this.topicFilters.category = category;
-  }
-
-  setFilter(filter: string) {
-    if (filter === 'all' || typeof filter !== 'string') filter = '';
-    this.engagmentsFilter$.next(filter);
-    this.topicFilters.engagements = filter;
-  }
-
-  setCountry(country: string) {
-    if (country === 'all' || typeof country !== 'string') country = '';
-    this.countryFilter$.next(country);
-    this.topicFilters.country = country;
-  }
-
-  setLanguage(language: string) {
-    if (language === 'all' || typeof language !== 'string') language = '';
-    this.languageFilter$.next(language);
-    this.topicFilters.language = language;
+  getActiveFilterText(key: keyof typeof this.filtersData, val: string) {
+    const value = val === '' ? 'all' : val;
+    return this.filtersData[key].items.find((item) => item.value === value)!.title;
   }
 
   doSearch(search: string) {
@@ -252,18 +324,14 @@ export class MyTopicsComponent {
   }
 
   onSelect(id: string) {
-    // this.UserTopicService.filterTopics(id);
     this.router.navigate([], { relativeTo: this.route, queryParams: { filter: id } });
   }
 
   doClearFilters() {
-    this.setVisibility('');
-    this.setFilter('');
-    this.orderBy('');
-    this.setStatus('');
-    this.setCategory('');
-    this.setCountry('');
-    this.setLanguage('');
+    const keys = this.filterKeys;
+    keys.forEach((key) => {
+      this.setFilterValue(key, '');
+    })
   }
 
   loadPage(page: any) {

--- a/src/app/my-topics/my-topics.component.ts
+++ b/src/app/my-topics/my-topics.component.ts
@@ -80,18 +80,6 @@ export class MyTopicsComponent {
         { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_FAVOURITED', value: "favourite"},
       ]
     },
-    status: {
-      isMobileOpen: false,
-      placeholder: "VIEWS.MY_TOPICS.FILTER_STATUS",
-      selectedValue: "",
-      preSelectedValue: "",
-      items: [
-        { title: 'TXT_TOPIC_STATUS_ALL', value: "all"},
-        ...Object.keys(this.Topic.STATUSES).map((status) => {
-          return { title: `TXT_TOPIC_STATUS_${status}`, value: status }
-        }),
-      ]
-    },
     engagements: {
       isMobileOpen: false,
       placeholder: "VIEWS.MY_TOPICS.FILTER_MY_ENGAGEMENT",
@@ -102,6 +90,18 @@ export class MyTopicsComponent {
         { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_VOTED', value: "hasVoted"},
         { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_HAVE_NOT_VOTED', value: "hasNotVoted"},
         { title: 'VIEWS.MY_TOPICS.FILTERS.TOPICS_I_CREATED', value: "iCreated"},
+      ]
+    },
+    status: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_STATUS",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'TXT_TOPIC_STATUS_ALL', value: "all"},
+        ...Object.keys(this.Topic.STATUSES).map((status) => {
+          return { title: `TXT_TOPIC_STATUS_${status}`, value: status }
+        }),
       ]
     },
     orderBy: {

--- a/src/app/public-groups/components/groups/groups.component.html
+++ b/src/app/public-groups/components/groups/groups.component.html
@@ -17,192 +17,37 @@
   </div>
   <div id="page_filters_wrap">
     <div id="options_area" [@openClose]="moreFilters ? 'open' : 'closed'" class="mobile_hidden">
-      <div class="options_row">
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.VISIBILITY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!groupFilters.visibility" translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL"></span>
-                <span *ngIf="groupFilters.visibility === 'favourite'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.FAVOURITED"></span>
+      <div class="options_row" [ngClass]="moreFilters? 'open' : 'closed'">
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <cos-input [placeholder]="filtersData[filterKey].placeholder| translate" class="dropdown_input">
+            <div class="dropdown" [cosDropdown]>
+              <div class="selection">
+                <div class="selected_item">
+                  <ng-container [ngSwitch]="filterKey">
+                    <span *ngSwitchCase="'visibility'">{{ getActiveFilterText("visibility", filtersData.visibility.selectedValue) | uppercase | translate | titlecase }}</span>
+                    <span *ngSwitchDefault>{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+                  </ng-container>
+                </div>
+                <div>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
+                  </svg>
+                </div>
               </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setVisibility('')">
-                {{'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}}
-              </div>
-              <div class="option" (click)="setVisibility('favourite')"
-                translate="VIEWS.PUBLIC_GROUPS.FILTERS.FAVOURITED" *ngIf="loggedIn()"></div>
-              <!--div class="option" [routerLink]="['./']" [queryParams]="{moderated: 'true'}"
-                translate="VIEWS.PUBLIC_GROUPS.FILTER_MODERATED"></!--div-->
-            </div>
-          </div>
-        </cos-input>
-        <!--cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.MY_ENGAGEMENT' | translate"
-          class="dropdown_input mobile_hidden" *ngIf="loggedIn()">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
+              <div class="options">
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <div class="option" (click)="setFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'visibility'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                  </div>
+                </ng-container>
               </div>
             </div>
-            <div class="options">
-              <div class="option">My most recent activity</div>
-              <div class="option">Groups I created</div>
-              <div class="option">Groups with pending requests</div>
-            </div>
-          </div>
-        </!--cos-input-->
-        <!--cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.CATEGORIES' | translate"
-          class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" *ngFor="let item of categories">
-                {{item}}
-              </div>
-            </div>
-          </div>
-        </!--cos-input-->
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.ORDER' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="!groupFilters.orderBy"> {{'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}} </span>
-                <span *ngIf="groupFilters.orderBy === 'activity'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.ORDER_RECENT_ACTIVITY"></span>
-                <span *ngIf="groupFilters.orderBy === 'activityCount'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_ACTIVITIES"></span>
-                <span *ngIf="groupFilters.orderBy === 'memberCount'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_PARTICIPANTS"></span>
-                <span *ngIf="groupFilters.orderBy === 'createdAt'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_RECENT"></span>
-                <span *ngIf="groupFilters.orderBy === 'topicCount'"
-                  translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_TOPICS"></span>
-              </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL" (click)="orderBy('')"></div>
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.ORDER_RECENT_ACTIVITY"
-                (click)="orderBy('activity')"></div>
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_ACTIVITIES"
-                (click)="orderBy('activityCount')"></div>
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_PARTICIPANTS"
-                (click)="orderBy('memberCount')"></div>
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_RECENT" (click)="orderBy('createdAt')">
-              </div>
-              <div class="option" translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_TOPICS" (click)="orderBy('topicCount')">
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.COUNTRY' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.country)? groupFilters.country : 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.LANGUAGE' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.language)? groupFilters.language : 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <!--div class="options_row mobile_show" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.MY_ENGAGEMENT' | translate"
-          class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option">My most recent activity</div>
-              <div class="option">Groups I created</div>
-              <div class="option">Groups with pending requests</div>
-            </div>
-          </div>
-        </cos-input>
-      </!--div-->
-      <div class="options_row tablet_show" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.country)? groupFilters.country : 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.LANGUAGE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(groupFilters.language)? groupFilters.language : 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <div class="options_row" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
+          </cos-input>
+        </ng-container>
+
         <div class="input_area">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -248,43 +93,14 @@
       </div>
 
       <div class="options filter_options">
-        <a class="filter_option" (click)="mobileFilters.visibility = true">
-          <span class="filter_option_text" translate="VIEWS.PUBLIC_GROUPS.FILTERS.VISIBILITY"></span>
-          <span class="bold">
-            <span *ngIf="!groupFilters.visibility" translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL"></span>
-            <span *ngIf="groupFilters.visibility === 'favourite'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.FAVOURITED"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.orderBy = true">
-          <span class="filter_option_text" translate="VIEWS.PUBLIC_GROUPS.FILTERS.ORDER"></span>
-          <span class="bold">
-            <span *ngIf="!groupFilters.orderBy"> {{'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' | translate}} </span>
-            <span *ngIf="groupFilters.orderBy === 'activity'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.ORDER_RECENT_ACTIVITY"></span>
-            <span *ngIf="groupFilters.orderBy === 'activityCount'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_ACTIVITIES"></span>
-            <span *ngIf="groupFilters.orderBy === 'memberCount'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_PARTICIPANTS"></span>
-            <span *ngIf="groupFilters.orderBy === 'createdAt'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_RECENT"></span>
-            <span *ngIf="groupFilters.orderBy === 'topicCount'"
-              translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_TOPICS"></span>
-          </span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.country = true">
-          <span class="filter_option_text" translate="VIEWS.PUBLIC_GROUPS.FILTERS.COUNTRY"></span>
-          <span class="bold">{{groupFilters.country || 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' |
-            translate}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.language = true">
-          <span class="filter_option_text" translate="VIEWS.PUBLIC_GROUPS.FILTERS.LANGUAGE"></span>
-          <span class="bold">{{groupFilters.language || 'VIEWS.PUBLIC_GROUPS.FILTERS.ALL' |
-            translate}}</span>
-        </a>
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <a class="filter_option" (click)="filtersData[filterKey].isMobileOpen = true">
+            <span class="filter_option_text">{{ filtersData[filterKey].placeholder | translate }}</span>
+            <ng-container [ngSwitch]="filterKey">
+              <span *ngSwitchDefault class="bold">{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+            </ng-container>
+          </a>
+        </ng-container>
 
         <button (click)="doClearFilters()" class="btn_medium_plain">
           <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -310,141 +126,91 @@
         </div>
       </div>
     </div>
-    <div class="overlay" *ngIf="showMobileOverlay()" (click)="closeMobileFilter()"></div>
-    <div class="mobile_filters_wrap" [ngClass]="{'active': showMobileOverlay()}">
-      <div class="options button_options" *ngIf="mobileFilters.visibility">
-        <label class="checkbox" (click)="mobileFilters.visibility = 'all'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.visibility = 'favourite'" *ngIf="loggedIn()">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.FAVOURITED"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <!--div class="option" (click)="mobileFilters.visibility = {favourite: 'true'}"
-          translate="VIEWS.PUBLIC_GROUPS.FILTERS.FAVOURITED"></!--div-->
 
-        <!--div class="option" (click)="mobileFilters.visibility = {moderated: 'true'}" translate="VIEWS.PUBLIC_GROUPS.FILTERS.MODERATED"></!--div-->
-        <button class="btn_medium_secondary" (click)="setVisibility(mobileFilters.visibility);mobileFilters.visibility= false;" translate="BTN_APPLY"></button>
-      </div>
-      <!--div class="options button_options" *ngIf="mobileFilters.category">
-        <label class="checkbox">
-          <span translate="TXT_TOPIC_CATEGORY_ALL"></span>
-          <input type="radio" name="category">
-          <span class="checkmark"></span>
-        </label>
+    <div class="overlay" *ngIf="hasMobileOpen" (click)="closeMobileFilter()"></div>
 
-        <label class="checkbox" *ngFor="let category of categories">
-          <span [translate]="'TXT_TOPIC_CATEGORY_'+category | uppercase"></span>
-          <input type="radio" name="category">
-          <span class="checkmark"></span>
-        </label>
+    <div class="mobile_filters_wrap" [ngClass]="{'active': hasMobileOpen}">
+      <ng-container *ngFor="let filterKey of filterKeys">
+        <div class="options button_options" *ngIf="filtersData[filterKey].isMobileOpen">
+          <ng-container [ngSwitch]="filterKey">
+            <search-filter
+              *ngSwitchCase="'country'"
+              [term]="countrySearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate"
+              [search]="searchCountry.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <button class="btn_medium_secondary" (click)="mobileFilters.category= false;" translate="BTN_APPLY"></button>
-      </!--div-->
-      <!--div class="options button_options" *ngIf="mobileFilters.my_engagement">
-        <label class="checkbox">
-          <span>My most recent activity</span>
-          <input type="radio" name="engagement">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox">
-          <span>Groups I created</span>
-          <input type="radio" name="engagement">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox">
-          <span>Groups with pending requests</span>
-          <input type="radio" name="engagement">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="mobileFilters.my_engagement = false;" translate="BTN_APPLY"></button>
-      </!--div-->
-      <div class="options button_options" *ngIf="mobileFilters.orderBy">
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'activity'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.ORDER_RECENT_ACTIVITY"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'activityCount'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_ACTIVITIES"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'memberCount'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_PARTICIPANTS"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'createdAt'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_RECENT"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.orderBy = 'topicCount'">
-          <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.MOST_TOPICS"></span>
-          <input type="radio" name="order">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="orderBy(mobileFilters.orderBy); mobileFilters.orderBy = false;"
-          translate="BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.country">
-        <search-filter
-          [term]="countrySearch"
-          [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.COUNTRY' | translate"
-          [search]="searchCountry.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
+            <search-filter
+              *ngSwitchCase="'language'"
+              [term]="languageSearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate"
+              [search]="searchLanguage.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.country = 'all'">
-            <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL"></span>
-            <input type="radio" name="country">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="countries$ | async as countries">
-            <label class="checkbox" *ngFor="let country of countries" (click)="mobileFilters.country = country.name">
-              <span>{{country.name}}</span>
-              <input type="radio" name="country">
-              <span class="checkmark"></span>
-            </label>
+            <a *ngSwitchDefault class="btn_medium_close icon" (click)="closeMobileFilter()">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289Z"
+                  fill="#2C3B47" />
+              </svg>
+            </a>
           </ng-container>
+
+          <div class="options_wrapper">
+            <ng-container [ngSwitch]="filterKey">
+              <ng-container *ngSwitchCase="'country'">
+                <label class="checkbox" (click)="filtersData.country.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
+                  <input type="radio" name="country">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="countries$ | async as countries">
+                  <label class="checkbox" *ngFor="let country of countries" (click)="filtersData.country.preSelectedValue = country.name;">
+                    <span>{{country.name}}</span>
+                    <input type="radio" name="country">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchCase="'language'">
+                <label class="checkbox" (click)="filtersData.language.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
+                  <input type="radio" name="language">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="languages$ | async as languages">
+                  <label class="checkbox" *ngFor="let language of languages" (click)="filtersData.language.preSelectedValue = language.name;">
+                    <span>{{language.name}}</span>
+                    <input type="radio" name="language">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchDefault>
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <label class="checkbox" (click)="chooseFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'visibility'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                    <input type="radio" name="{{filterKey}}">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+            </ng-container>
+          </div>
+  
+          <button class="btn_medium_secondary" (click)="setFilterValue(filterKey, filtersData[filterKey].preSelectedValue); closeMobileFilter();"
+            translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
         </div>
-
-        <button class="btn_medium_secondary"
-          (click)="setCountry(mobileFilters.country.trim()); closeMobileFilter();"
-          translate="BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.language">
-        <search-filter
-          [term]="languageSearch"
-          [placeholder]="'VIEWS.PUBLIC_GROUPS.FILTERS.LANGUAGE' | translate"
-          [search]="searchLanguage.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
-
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.language = 'all'">
-            <span translate="VIEWS.PUBLIC_GROUPS.FILTERS.ALL"></span>
-            <input type="radio" name="language">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="languages$ | async as languages">
-            <label class="checkbox" *ngFor="let language of languages" (click)="mobileFilters.language = language.name">
-              <span>{{language.name}}</span>
-              <input type="radio" name="language">
-              <span class="checkmark"></span>
-            </label>
-          </ng-container>
-        </div>
-
-        <button class="btn_medium_secondary"
-          (click)="setLanguage(mobileFilters.language.trim()); closeMobileFilter();"
-          translate="BTN_APPLY"></button>
-      </div>
+      </ng-container>
     </div>
   </div>
   <div class="groups_content">

--- a/src/app/public-groups/components/groups/groups.component.scss
+++ b/src/app/public-groups/components/groups/groups.component.scss
@@ -50,12 +50,41 @@
 
     .options_row {
       display: flex;
+      flex-wrap: wrap;
       gap: 16px;
       width: 100%;
       position: relative;
 
+      @include mixins.desktop {
+        &.open {
+          .dropdown_input:nth-of-type(n+5), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+5),
+          .input_area {
+            display: none;
+          }
+        }
+      }
+
       @include mixins.tablet {
-        flex-flow: row wrap;
+        &.open {
+          .dropdown_input:nth-of-type(n+3), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+3),
+          .input_area {
+            display: none;
+          }
+        }
       }
 
       .dropdown_input {

--- a/src/app/public-groups/components/groups/groups.component.ts
+++ b/src/app/public-groups/components/groups/groups.component.ts
@@ -36,22 +36,6 @@ export class GroupsComponent implements OnInit {
   moreFilters = false;
   searchInput = '';
   searchString$ = new BehaviorSubject('');
-  mobileFilters:any = {
-    visibility: false,
-    my_engagement: false,
-    category: false,
-    orderBy: false,
-    country: false,
-    language: false
-  }
-  groupFilters = {
-    visibility: '',
-    my_engagement: '',
-    category: '',
-    orderBy: '',
-    country: '',
-    language: ''
-  };
 
   visibilityFilter$ = new BehaviorSubject('');
   engagmentsFilter$ = new BehaviorSubject('');

--- a/src/app/public-topics/components/topics/topics.component.html
+++ b/src/app/public-topics/components/topics/topics.component.html
@@ -17,180 +17,40 @@
   </div>
   <div id="page_filters_wrap">
     <div id="options_area" [@openClose]="moreFilters ? 'open' : 'closed'" class="mobile_hidden">
-      <div class="options_row">
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_STATUS' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">
-                <span *ngIf="topicFilters.status === 'showModerated'"
-                  translate="COMPONENTS.PUBLIC_TOPICS.FILTER_TOPICS_MODERATED"></span>
-                <ng-container *ngIf="topicFilters.status !== 'showModerated'">
-                  <span>
-                    {{('TXT_TOPIC_STATUS_' + (topicFilters.status || 'all')) | uppercase | translate |
-                    titlecase}}</span>
+      <div class="options_row" [ngClass]="moreFilters? 'open' : 'closed'">
+
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <cos-input [placeholder]="filtersData[filterKey].placeholder| translate" class="dropdown_input">
+            <div class="dropdown" [cosDropdown]>
+              <div class="selection">
+                <div class="selected_item">
+                  <ng-container [ngSwitch]="filterKey">
+                    <span *ngSwitchCase="'status'">{{ getActiveFilterText("status", filtersData.status.selectedValue) | uppercase | translate | titlecase }}</span>
+                    <span *ngSwitchCase="'category'">{{ getActiveFilterText("category", filtersData.category.selectedValue) | uppercase | translate }}</span>
+                    <span *ngSwitchDefault>{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+                  </ng-container>
+                </div>
+                <div>
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
+                  </svg>
+                </div>
+              </div>
+              <div class="options">
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <div class="option" (click)="setFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'status'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchCase="'category'">{{ option.title | uppercase | translate }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                  </div>
                 </ng-container>
               </div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
             </div>
-            <div class="options">
-              <div class="option" (click)="setStatus('');"
-                [innerHTML]="'TXT_TOPIC_STATUS_ALL' | translate | titlecase"></div>
-              <div class="option" (click)="setStatus('showModerated');"
-                translate="COMPONENTS.PUBLIC_TOPICS.FILTER_TOPICS_MODERATED"></div>
-              <div class="option" *ngFor="let status of statuses$" (click)="setStatus(status);">
-                {{'TXT_TOPIC_STATUS_' + status | uppercase | translate | titlecase}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <!--cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_MY_ENGAGEMENT' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option">My most recent activity</div>
-              <div class="option">Groups I created</div>
-              <div class="option">Groups with pending requests</div>
-            </div>
-          </div>
-        </!--cos-input-->
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_CATEGORIES' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{'TXT_TOPIC_CATEGORY_'+(topicFilters.category || 'all') | uppercase |
-                translate | titlecase}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCategory('all');" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let category of categories$" (click)="setCategory(category);">
-                {{'TXT_TOPIC_CATEGORY_' + category | uppercase | translate}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_COUNTRY' | translate" class="dropdown_input tablet_hidden">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(topicFilters.country)?
-                this.topicFilters.country : 'COMPONENTS.PUBLIC_TOPICS.FILTER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
+          </cos-input>
+        </ng-container>
 
-        <!--cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" *ngFor="let item of []">
-                {{item}}
-              </div>
-            </div>
-          </div>
-        </cos-input-->
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_LANGUAGE' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(topicFilters.language && topicFilters.language !== 'all')?
-                topicFilters.language : 'COMPONENTS.PUBLIC_TOPICS.FILTER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setLanguage('')" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_ALL"></div>
-              <div class="option" *ngFor="let language of languages" (click)="setLanguage(language.name)">
-                {{language.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <!--cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_ORDER' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">All</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option">Most recent participant activity</div>
-              <div class="option">Most activity</div>
-              <div class="option">Most participants</div>
-              <div class="option">Most recently created</div>
-              <div class="option">Most topics</div>
-            </div>
-          </div>
-        </!--cos-input-->
-      </div>
-      <div class="options_row tablet_show" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_CATEGORIES' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{'TXT_TOPIC_CATEGORY_'+(topicFilters.category || 'all') | uppercase |
-                translate | titlecase}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCategory('all');" translate="TXT_TOPIC_CATEGORY_ALL"></div>
-              <div class="option" *ngFor="let category of categories$" (click)="setCategory(category);">
-                {{'TXT_TOPIC_CATEGORY_' + category | uppercase | translate}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-        <cos-input [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_COUNTRY' | translate" class="dropdown_input">
-          <div class="dropdown" [cosDropdown]>
-            <div class="selection">
-              <div class="selected_item">{{(topicFilters.country)?
-                this.topicFilters.country : 'COMPONENTS.PUBLIC_TOPICS.FILTER_ALL' | translate}}</div>
-              <div><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M17 10L12 15L7 10" stroke="#2C3B47" stroke-width="2" stroke-linecap="round" />
-                </svg>
-              </div>
-            </div>
-            <div class="options">
-              <div class="option" (click)="setCountry('')" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_ALL"></div>
-              <div class="option" *ngFor="let country of countries" (click)="setCountry(country.name)">
-                {{country.name}}
-              </div>
-            </div>
-          </div>
-        </cos-input>
-      </div>
-      <div class="options_row" *ngIf="moreFilters" [@openClose]="moreFilters ? 'open' : 'closed'">
         <div class="input_area">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -236,29 +96,16 @@
       </div>
 
       <div class="options filter_options">
-        <a class="filter_option" (click)="mobileFilters.status = true">
-          <span class="filter_option_text" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_VISIBILITY"></span>
-          <span class="bold">{{'TXT_TOPIC_STATUS_' + (topicFilters.status || 'all') | uppercase |
-            translate | titlecase}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.category = true">
-          <span class="filter_option_text" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_CATEGORIES"></span>
-          <span class="bold">{{'TXT_TOPIC_CATEGORY_'+ (topicFilters.category || 'all') | uppercase |
-            translate | titlecase}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.country = true">
-          <span class="filter_option_text" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_COUNTRY"></span>
-          <span class="bold">{{(topicFilters.country)?
-              topicFilters.country : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</span>
-        </a>
-
-        <a class="filter_option" (click)="mobileFilters.language = true">
-          <span class="filter_option_text" translate="COMPONENTS.PUBLIC_TOPICS.FILTER_LANGUAGE"></span>
-          <span class="bold">{{(topicFilters.language)?
-              topicFilters.language : 'VIEWS.MY_TOPICS.FILTER_ALL' | translate}}</span>
-        </a>
+        <ng-container *ngFor="let filterKey of filterKeys">
+          <a class="filter_option" (click)="filtersData[filterKey].isMobileOpen= true">
+            <span class="filter_option_text">{{ filtersData[filterKey].placeholder| translate }}</span>
+            <ng-container [ngSwitch]="filterKey">
+              <span *ngSwitchCase="'status'" class="bold">{{ getActiveFilterText("status", filtersData.status.selectedValue) | uppercase | translate | titlecase }}</span>
+              <span *ngSwitchCase="'category'" class="bold">{{ getActiveFilterText("category", filtersData.category.selectedValue) | uppercase | translate }}</span>
+              <span *ngSwitchDefault class="bold">{{ getActiveFilterText(filterKey, filtersData[filterKey].selectedValue) | translate }}</span>
+            </ng-container>
+          </a>
+        </ng-container>
 
         <button (click)="doClearFilters()" class="btn_medium_plain">
           <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -284,99 +131,92 @@
         </div>
       </div>
     </div>
-    <div class="overlay" *ngIf="showMobileOverlay()" (click)="closeMobileFilter();"></div>
-    <div class="mobile_filters_wrap" [ngClass]="{'active': showMobileOverlay()}">
-      <div class="options button_options" *ngIf="mobileFilters.status">
-        <label class="checkbox" (click)="mobileFilters.status = 'all';">
-          <span [innerHTML]="'TXT_TOPIC_STATUS_ALL' | translate | titlecase"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" *ngFor="let status of statuses$" (click)="mobileFilters.status = status">
-          <span [innerHtml]="'TXT_TOPIC_STATUS_'+status | uppercase | translate | titlecase"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <label class="checkbox" (click)="mobileFilters.status = 'showModerated';">
-          <span translate="COMPONENTS.PUBLIC_TOPICS.FILTER_TOPICS_MODERATED"></span>
-          <input type="radio" name="status">
-          <span class="checkmark"></span>
-        </label>
-        <button class="btn_medium_secondary" (click)="setStatus(mobileFilters.status);mobileFilters.status= false;"
-          translate="COMPONENTS.PUBLIC_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.category">
-        <div class="options_wrapper">
-          <label class="checkbox" (click)=" mobileFilters.category = 'all'">
-            <span translate="TXT_TOPIC_CATEGORY_ALL"></span>
-            <input type="radio" name="category">
-            <span class="checkmark"></span>
-          </label>
 
-          <label class="checkbox" *ngFor="let category of categories$" (click)=" mobileFilters.category = category">
-            <span [translate]="'TXT_TOPIC_CATEGORY_'+category | uppercase"></span>
-            <input type="radio" name="category">
-            <span class="checkmark"></span>
-          </label>
-        </div>
+    <div class="overlay" *ngIf="hasMobileOpen" (click)="closeMobileFilter();"></div>
 
-        <button class="btn_medium_secondary"
-          (click)="setCategory(mobileFilters.category);mobileFilters.category= false;"
-          translate="COMPONENTS.PUBLIC_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.country">
-        <search-filter
-          [term]="countrySearch"
-          [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_COUNTRY' | translate"
-          [search]="searchCountry.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
+    <div class="mobile_filters_wrap" [ngClass]="{'active': hasMobileOpen}">
+      <ng-container *ngFor="let filterKey of filterKeys">
+        <div class="options button_options" *ngIf="filtersData[filterKey].isMobileOpen">
+          <ng-container [ngSwitch]="filterKey">
+            <search-filter
+              *ngSwitchCase="'country'"
+              [term]="countrySearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_COUNTRY' | translate"
+              [search]="searchCountry.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
 
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.country = 'all'">
-            <span translate="TXT_TOPIC_STATUS_ALL"></span>
-            <input type="radio" name="country">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="countries$ | async as countries">
-            <label class="checkbox" *ngFor="let country of countries" (click)="mobileFilters.country = country.name">
-              <span>{{country.name}}</span>
-              <input type="radio" name="country">
-              <span class="checkmark"></span>
-            </label>
+            <search-filter
+              *ngSwitchCase="'language'"
+              [term]="languageSearch"
+              [placeholder]="'VIEWS.MY_TOPICS.FILTER_LANGUAGE' | translate"
+              [search]="searchLanguage.bind(this)"
+              [close]="closeMobileFilter.bind(this)"
+            />
+
+            <a *ngSwitchDefault class="btn_medium_close icon" (click)="closeMobileFilter()">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289Z"
+                  fill="#2C3B47" />
+              </svg>
+            </a>
           </ng-container>
+
+          <div class="options_wrapper">
+            <ng-container [ngSwitch]="filterKey">
+              <ng-container *ngSwitchCase="'country'">
+                <label class="checkbox" (click)="filtersData.country.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_TOPICS.FILTER_ALL"></span>
+                  <input type="radio" name="country">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="countries$ | async as countries">
+                  <label class="checkbox" *ngFor="let country of countries" (click)="filtersData.country.preSelectedValue = country.name;">
+                    <span>{{country.name}}</span>
+                    <input type="radio" name="country">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchCase="'language'">
+                <label class="checkbox" (click)="filtersData.language.preSelectedValue = 'all'">
+                  <span translate="VIEWS.MY_GROUPS.FILTER_ALL"></span>
+                  <input type="radio" name="language">
+                  <span class="checkmark"></span>
+                </label>
+            
+                <ng-container *ngIf="languages$ | async as languages">
+                  <label class="checkbox" *ngFor="let language of languages" (click)="filtersData.language.preSelectedValue = language.name;">
+                    <span>{{language.name}}</span>
+                    <input type="radio" name="language">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+
+              <ng-container *ngSwitchDefault>
+                <ng-container *ngFor="let option of filtersData[filterKey].items">
+                  <label class="checkbox" (click)="chooseFilterValue(filterKey, option.value)">
+                    <ng-container [ngSwitch]="filterKey">
+                      <span *ngSwitchCase="'status'">{{ option.title | uppercase | translate | titlecase }}</span>
+                      <span *ngSwitchCase="'category'">{{ option.title | uppercase | translate }}</span>
+                      <span *ngSwitchDefault>{{ option.title | translate }}</span>
+                    </ng-container>
+                    <input type="radio" name="{{filterKey}}">
+                    <span class="checkmark"></span>
+                  </label>
+                </ng-container>
+              </ng-container>
+            </ng-container>
+          </div>
+  
+          <button class="btn_medium_secondary" (click)="setFilterValue(filterKey, filtersData[filterKey].preSelectedValue); closeMobileFilter();"
+            translate="VIEWS.MY_TOPICS.BTN_APPLY"></button>
         </div>
-
-        <button class="btn_medium_secondary" (click)="setCountry(mobileFilters.country); closeMobileFilter();"
-          translate="COMPONENTS.PUBLIC_TOPICS.BTN_APPLY"></button>
-      </div>
-      <div class="options button_options" *ngIf="mobileFilters.language">
-        <search-filter
-          [term]="languageSearch"
-          [placeholder]="'COMPONENTS.PUBLIC_TOPICS.FILTER_LANGUAGE' | translate"
-          [search]="searchLanguage.bind(this)"
-          [close]="closeMobileFilter.bind(this)"
-        />
-
-        <div class="options_wrapper">
-          <label class="checkbox" (click)="mobileFilters.language = 'all'">
-            <span translate="TXT_TOPIC_STATUS_ALL"></span>
-            <input type="radio" name="language">
-            <span class="checkmark"></span>
-          </label>
-          <ng-container *ngIf="languages$ | async as languages">
-            <label class="checkbox" *ngFor="let language of languages" (click)="mobileFilters.language = language.name;">
-              <span>{{language.name}}</span>
-              <input type="radio" name="language">
-              <span class="checkmark"></span>
-            </label>
-          </ng-container>
-        </div>
-
-        <button class="btn_medium_secondary"
-          (click)="setLanguage(mobileFilters.language); closeMobileFilter();"
-          translate="COMPONENTS.PUBLIC_TOPICS.BTN_APPLY"></button>
-      </div>
+      </ng-container>
     </div>
   </div>
   <div class="topics_content">

--- a/src/app/public-topics/components/topics/topics.component.scss
+++ b/src/app/public-topics/components/topics/topics.component.scss
@@ -53,12 +53,41 @@
 
     .options_row {
       display: flex;
+      flex-wrap: wrap;
       gap: 16px;
       width: 100%;
       position: relative;
 
+      @include mixins.desktop {
+        &.open {
+          .dropdown_input:nth-of-type(n+5), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+5),
+          .input_area {
+            display: none;
+          }
+        }
+      }
+    
       @include mixins.tablet {
-        flex-flow: row wrap;
+        &.open {
+          .dropdown_input:nth-of-type(n+3), 
+          .input_area {
+            display: flex;
+          }
+        }
+  
+        &.closed {
+          .dropdown_input:nth-of-type(n+3),
+          .input_area {
+            display: none;
+          }
+        }
       }
 
       .dropdown_input {

--- a/src/app/public-topics/components/topics/topics.component.ts
+++ b/src/app/public-topics/components/topics/topics.component.ts
@@ -78,6 +78,72 @@ export class TopicsComponent implements OnInit {
   allTopics$: Topic[] = [];
   destroy$ = new Subject<boolean>();
 
+  filtersData = {
+    status: {
+      isMobileOpen: false,
+      placeholder: "COMPONENTS.PUBLIC_TOPICS.FILTER_STATUS",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'TXT_TOPIC_STATUS_ALL', value: "all"},
+        { title: 'COMPONENTS.PUBLIC_TOPICS.FILTER_TOPICS_MODERATED', value: "showModerated"},
+        ...Object.keys(this.Topic.STATUSES).map((status) => {
+          return { title: `TXT_TOPIC_STATUS_${status}`, value: status }
+        }),
+      ]
+    },
+    category: {
+      isMobileOpen: false,
+      placeholder: "COMPONENTS.PUBLIC_TOPICS.FILTER_CATEGORIES",
+      selectedValue: "",
+      preSelectedValue: "",
+      items: [
+        { title: 'TXT_TOPIC_CATEGORY_ALL', value: "all"},
+        ...Object.keys(this.Topic.CATEGORIES).map((cat) => {
+          return { title: `TXT_TOPIC_CATEGORY_${cat}`, value: cat }
+        }),
+      ]
+    },
+    country: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_COUNTRY",
+      selectedValue: "",
+      preSelectedValue: "",
+      /**
+       * @note Only for desktop. For mobile it looks for observable.
+       */
+      items: [
+        { title: 'VIEWS.MY_TOPICS.FILTER_ALL', value: "all"},
+        ...this.countries.map((it) => {
+          return { title: it.name, value: it.name }
+        }),
+      ]
+    },
+    language: {
+      isMobileOpen: false,
+      placeholder: "VIEWS.MY_TOPICS.FILTER_LANGUAGE",
+      selectedValue: "",
+      preSelectedValue: "",
+      /**
+       * @note Only for desktop. For mobile it looks for observable.
+       */
+      items: [
+        { title: 'VIEWS.MY_GROUPS.FILTER_ALL', value: "all"},
+        ...this.languages.map((it) => {
+          return { title: it.name, value: it.name }
+        }),
+      ]
+    },
+  };
+
+  get filterKeys() {
+    return Object.keys(this.filtersData) as Array<keyof typeof this.filtersData>;
+  }
+
+  get hasMobileOpen() {
+    return Object.values(this.filtersData).some((filter) => filter.isMobileOpen);
+  }
+
   constructor(
     private route: ActivatedRoute,
     private Topic: TopicService,
@@ -174,42 +240,6 @@ export class TopicsComponent implements OnInit {
     return element.id;
   }
 
-  orderBy(orderBy: string) {
-    if (orderBy === 'all' || typeof orderBy !== 'string') orderBy = '';
-    this.orderFilter$.next(orderBy);
-    this.topicFilters.orderBy = orderBy;
-  }
-
-  setStatus(status: string) {
-    if (status === 'all'|| typeof status !== 'string') status = '';
-    this.statusFilter$.next(status);
-    this.topicFilters.status = status;
-  }
-
-  setCategory(category: string) {
-    if (category === 'all' || typeof category !== 'string') category = '';
-    this.categoryFilter$.next(category);
-    this.topicFilters.category = category;
-  }
-
-  setCountry(country: string) {
-    if (country === 'all' || typeof country !== 'string') country = '';
-    this.countryFilter$.next(country);
-    this.topicFilters.country = country;
-
-    this.countrySearch$.next(country);
-    this.countrySearch = country;
-  }
-
-  setLanguage(language: string) {
-    if (language === 'all' || typeof language !== 'string') language = '';
-    this.languageFilter$.next(language);
-    this.topicFilters.language = language;
-
-    this.languageSearch$.next(language);
-    this.languageSearch = language;
-  }
-
   ngOnInit(): void {
   }
 
@@ -219,37 +249,60 @@ export class TopicsComponent implements OnInit {
   }
 
   closeMobileFilter() {
-    const filtersShow = Object.entries(this.mobileFilters).find(([key, value]) => {
-      return !!value;
+    const keys = this.filterKeys;
+
+    keys.forEach((key) => {
+      this.filtersData[key].isMobileOpen = false;
+      this.filtersData[key].preSelectedValue = "";
+      switch(key) {
+        case "language": {
+          this.languageSearch$.next(this.languageSearch);
+          break;
+        }
+        case "country": {
+          this.countrySearch$.next(this.countrySearch);
+          break;
+        }
+        default:
+      }
     })
-    if (filtersShow) {
-      const filterName = filtersShow[0]
-      this.mobileFilters[filterName] = false;
-      if (filterName === 'language') {
-        this.languageSearch$.next(this.languageSearch);
-      }
-      if (filterName === 'country') {
-        this.countrySearch$.next(this.countrySearch);
-      }
-    }
   }
 
-  showMobileOverlay() {
-    const filtersShow = Object.entries(this.mobileFilters).find(([key, value]) => {
-      return !!value;
-    })
-    if (filtersShow) return true;
+  getActiveFilterText(key: keyof typeof this.filtersData, val: string) {
+    const value = val === '' ? 'all' : val;
+    return this.filtersData[key].items.find((item) => item.value === value)!.title;
+  }
 
-    return false;
+  chooseFilterValue (type: keyof typeof this.filtersData, option: string) {
+    this.filtersData[type].preSelectedValue = option;
+  }
+
+  setFilterValue(filter: keyof typeof this.filtersData, val: string) {
+    const value = val === 'all' ? '' : val;
+    switch (filter) {
+      case 'status':
+        this.statusFilter$.next(value);
+        break;
+      case 'category':
+        this.categoryFilter$.next(value);
+        break;
+      case 'country':
+        this.countryFilter$.next(value);
+        break;
+      case 'language':
+        this.languageFilter$.next(value);
+        break;
+      default:
+    }
+
+    this.filtersData[filter].selectedValue = value;
   }
 
   doClearFilters() {
-    this.setStatus('');
-    this.setCategory('');
-    this.setCountry('');
-    this.setLanguage('');
-    this.searchInput = '';
-    this.doSearch('');
+    const keys = this.filterKeys;
+    keys.forEach((key) => {
+      this.setFilterValue(key, '');
+    })
   }
 
   ngOnDestroy(): void {
@@ -259,8 +312,6 @@ export class TopicsComponent implements OnInit {
   isFilterApplied() {
     return this.topicFilters.category !== this.FILTERS_ALL || this.topicFilters.status !== this.FILTERS_ALL || this.topicFilters.country !== '' || this.topicFilters.country !== '';
   };
-
-  //mew
 
   doSearch(search: string) {
     this.searchString$.next(search);

--- a/src/app/public-topics/components/topics/topics.component.ts
+++ b/src/app/public-topics/components/topics/topics.component.ts
@@ -31,12 +31,10 @@ import { Language } from 'src/app/interfaces/language';
 })
 export class TopicsComponent implements OnInit {
 
-  //mew
   moreFilters = false;
   searchInput = '';
   searchString$ = new BehaviorSubject('');
   topics$ = of(<Topic[] | any[]>[]);
-  //new
   public FILTERS_ALL = 'all';
   countrySearch = '';
   countrySearch$ = new BehaviorSubject('');
@@ -51,30 +49,14 @@ export class TopicsComponent implements OnInit {
     return a.name.localeCompare(b.name);
   });
   languages$ = of(<Language[]>[]);
-  topicFilters = {
-    category: '',
-    orderBy: '',
-    status: '',
-    country: '',
-    language: ''
-  };
   statusFilter$ = new BehaviorSubject('');
   orderFilter$ = new BehaviorSubject('');
   categoryFilter$ = new BehaviorSubject('');
   countryFilter$ = new BehaviorSubject('');
   languageFilter$ = new BehaviorSubject('');
 
-  mobileFilters: any = {
-    category: false,
-    status: false,
-    orderBy: '',
-    country: false,
-    language: false,
-  }
   mobileFiltersList = false;
-  categories$ = Object.keys(this.Topic.CATEGORIES);
 
-  statuses$ = Object.keys(this.Topic.STATUSES);
   allTopics$: Topic[] = [];
   destroy$ = new Subject<boolean>();
 
@@ -308,10 +290,6 @@ export class TopicsComponent implements OnInit {
   ngOnDestroy(): void {
     this.destroy$.next(true);
   }
-
-  isFilterApplied() {
-    return this.topicFilters.category !== this.FILTERS_ALL || this.topicFilters.status !== this.FILTERS_ALL || this.topicFilters.country !== '' || this.topicFilters.country !== '';
-  };
 
   doSearch(search: string) {
     this.searchString$.next(search);

--- a/src/app/services/topic.service.ts
+++ b/src/app/services/topic.service.ts
@@ -13,7 +13,7 @@ import { Router } from '@angular/router';
   providedIn: 'root'
 })
 export class TopicService {
-  public CATEGORIES = <any>{
+  public CATEGORIES = {
     agriculture: "agriculture",
     animal_protection: "animal_protection",
     arts: "arts",

--- a/src/app/services/topic.service.ts
+++ b/src/app/services/topic.service.ts
@@ -46,7 +46,7 @@ export class TopicService {
     youth: "youth",
   };
 
-  public STATUSES = <any>{
+  public STATUSES = {
     draft: 'draft',
     ideation: 'ideation',
     inProgress: 'inProgress', // Being worked on
@@ -228,7 +228,7 @@ export class TopicService {
     return (topic?.permission && topic.permission.level === this.LEVELS.admin && topic.status !== this.STATUSES.closed);
   };
 
-  changeState(topic: Topic, state: string, stateSuccess?: string) {
+  changeState(topic: Topic, state: keyof typeof this.STATUSES, stateSuccess?: string) {
     const templates = <any>{
       closed: {
         level: 'delete',
@@ -261,7 +261,7 @@ export class TopicService {
           }).pipe(take(1))
             .subscribe({
               next: () => {
-                if (state === 'vote' && !topic.voteId && !topic.vote) {
+                if (state === 'voting' && !topic.voteId && !topic.vote) {
                   this.router.navigate(['/topics', topic.id, 'votes', 'create'])
                 }
                 this.reloadTopic();
@@ -283,7 +283,7 @@ export class TopicService {
       }).pipe(take(1))
         .subscribe({
           next: () => {
-            if (state === 'vote' && !topic.voteId && !topic.vote) {
+            if (state === 'voting' && !topic.voteId && !topic.vote) {
               this.router.navigate(['/topics', topic.id, 'votes', 'create'])
             }
             this.reloadTopic();

--- a/src/app/topic/topic.component.ts
+++ b/src/app/topic/topic.component.ts
@@ -369,7 +369,7 @@ export class TopicComponent {
   }
 
   closeTopic(topic: Topic) {
-    this.TopicService.changeState(topic, this.TopicService.STATUSES.closed);
+    this.TopicService.changeState(topic, "closed");
   }
 
   joinTopic(topic: Topic) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2028,6 +2028,10 @@ tour-item-template {
     visibility: visible;
   }
 
+  .btn_medium_close {
+    margin-left: auto;
+  }
+
   .options {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Intro

There are tons of repeated code for filters across my-groups/my-topics/groups/topics. 
The idea is to:
- reduce amount of repeated code
- simplify filters view and component

### Description

Html view tightly tied to data, html code repeated for mobile/desktop and partially for tablets, which make editing and making modifications a really challenging.
The idea is to separate data for filters for component/view, to have a better control over filters data and have a single source for mobile/desktop.

```
Record<string, {
  isMobileOpen: boolean;
  placeholder: string;
  selectedValue: string;
  preSelectedValue: string;
  items: { title: string; value: string; }[]
}>
```

This helps to have some consistency for filters rendering.

Additionally, there was extra part only for tablets, **tablet_show**, which is extra and can be removed and replaces with css styles

### Issues fixed

- my-topics -> desktop -> status filter
There is the only place where filter options have checkboxes for desktop. Updated with common filters view
<img width="888" alt="image" src="https://github.com/user-attachments/assets/c7361ebe-d0bd-4662-9527-520eb4263a67" />
- my-groups -> desktop/mobile -> all filters
For some reason it's just on this page where there are additional borders and paddings for the filters. Updated with common filters view
<img width="891" alt="image" src="https://github.com/user-attachments/assets/a379b8eb-55d7-4a8a-b94f-26b6f8eda495" />
<img width="420" alt="image" src="https://github.com/user-attachments/assets/2146cba7-bf05-48b1-9ab9-fdf327bccd97" />
- public topics -> status filter
Placeholder changes from "Status" on desktop to "Visibility" on mobile. Update to "Status" both on desktop/mobile

### Steps to test:

- go to
  - my groups
  - my topics
  - public groups
  - public topics
- test all filters combinations
- they should work as before and have consistent view
