### PR TITLE
Fix redirect after click on "User liked an idea"

### DIFF
--- a/src/app/services/activity.service.ts
+++ b/src/app/services/activity.service.ts
@@ -694,7 +694,13 @@ export class ActivityService extends ItemsListService {
       state = state.concat(['topics', origin.id]);
     }
 
-    if (state.length) {
+    /**
+     * @note Assume that the first item is always present and is lang param.
+     * No action needed in this case.
+     * 
+     * @fix https://github.com/citizenos/citizenos-fe/issues/1737
+     */
+    if (state.length > 1) {
       if (hash) {
         params.fragment = hash;
       }


### PR DESCRIPTION
Steps to test:
- like any idea
- open "Group activity" sidebar
- click on fresh "User liked an idea" item

Current:
- redirect to DB

Expected:
- no redirect

> Note: @ilmartyrk can you please check possible side effects on this, cause the function logic is too complicated and unclear. I made a quick fix, but I'm not sure whether it's going to work as expected. If not, then I'll close this pr and create another solution.