### PR TITLE
Show error as label under input instead of toast [#1739]

### DIFF
--- a/src/app/ideation/components/ideation-create/ideation-create.component.html
+++ b/src/app/ideation/components/ideation-create/ideation-create.component.html
@@ -285,7 +285,7 @@
                       [disabled]="!TopicService.canEditDescription(topic)"
                       [ngClass]="{'disabled': !TopicService.canEditDescription(topic)}"></button>
                   </div>
-                  <div class="inline_notification error" *ngIf="errors?.image">
+                  <div class="inline_notification error" *ngIf="error?.image">
                     <div class="icon_notification">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <rect width="24" height="24" rx="12" fill="#EF4025" />
@@ -294,7 +294,7 @@
                           fill="white" stroke="white" stroke-linecap="round" />
                       </svg>
                     </div>
-                    <div [innerHtml]="errors.image">
+                    <div [innerHtml]="error.image">
                     </div>
                   </div>
                   <div id="topic_image" class="block_section" *ngIf="(topic.imageUrl || tmpImageUrl)">
@@ -925,8 +925,7 @@
                         <span class="checkmark"></span>
                         <div class="checkbox_text_wrap">
                           <span class="bold" translate="VIEWS.IDEATION_CREATE.LBL_OPTION_DEADLINE"></span>
-                          <span class="deadline bold" *ngIf="deadlineSelect">{{deadline | date: 'YYYY-MM-dd
-                            HH:mm'}}</span>
+                          <span class="deadline bold" *ngIf="deadlineSelect">{{deadline | date: 'YYYY-MM-dd HH:mm'}}</span>
                         </div>
                       </label>
                     </div>

--- a/src/app/topic/components/topic-form/topic-form.component.html
+++ b/src/app/topic/components/topic-form/topic-form.component.html
@@ -899,8 +899,7 @@
                       <span class="checkmark"></span>
                       <div class="checkbox_text_wrap">
                         <span class="bold" translate="VIEWS.TOPIC_CREATE.LBL_OPTION_DEADLINE"></span>
-                        <span class="deadline bold" *ngIf="deadlineSelect">{{deadline | date: 'YYYY-MM-dd
-                          HH:mm'}}</span>
+                        <span class="deadline bold" *ngIf="deadlineSelect">{{deadline | date: 'YYYY-MM-dd HH:mm'}}</span>
                       </div>
                     </label>
                   </div>

--- a/src/app/topic/components/topic-form/topic-form.component.ts
+++ b/src/app/topic/components/topic-form/topic-form.component.ts
@@ -413,7 +413,6 @@ export class TopicFormComponent {
   fileUpload() {
     const allowedTypes = ['image/gif', 'image/jpeg', 'image/png', 'image/svg+xml'];
     const files = this.fileInput?.nativeElement.files;
-    console.log(files, files[0].size);
     if (allowedTypes.indexOf(files[0].type) < 0) {
       this.error = { image: this.translate.instant('MSG_ERROR_FILE_TYPE_NOT_ALLOWED', { allowedFileTypes: allowedTypes.toString() }) };
       this.Notification.addError(this.translate.instant('MSG_ERROR_FILE_TYPE_NOT_ALLOWED', { allowedFileTypes: allowedTypes.toString() }));
@@ -421,7 +420,7 @@ export class TopicFormComponent {
         delete this.error.image;
       }, 5000)
     } else if (files[0].size > 5000000) {
-      this.Notification.addError(this.translate.instant('MSG_ERROR_FILE_TOO_LARGE', { allowedFileSize: '5MB' }));
+      // this.Notification.addError(this.translate.instant('MSG_ERROR_FILE_TOO_LARGE', { allowedFileSize: '5MB' }));
       this.error = { image: this.translate.instant('MSG_ERROR_FILE_TOO_LARGE', { allowedFileSize: '5MB' }) };
 
       setTimeout(() => {

--- a/src/app/voting/components/vote-create/vote-create.component.html
+++ b/src/app/voting/components/vote-create/vote-create.component.html
@@ -283,7 +283,7 @@
                       [disabled]="!TopicService.canEditDescription(topic)"
                       [ngClass]="{'disabled': !TopicService.canEditDescription(topic)}"></button>
                   </div>
-                  <div class="inline_notification error" *ngIf="errors?.image">
+                  <div class="inline_notification error" *ngIf="error?.image">
                     <div class="icon_notification">
                       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <rect width="24" height="24" rx="12" fill="#EF4025" />
@@ -292,7 +292,7 @@
                           fill="white" stroke="white" stroke-linecap="round" />
                       </svg>
                     </div>
-                    <div [innerHtml]="errors.image">
+                    <div [innerHtml]="error.image">
                     </div>
                   </div>
                   <div id="topic_image" class="block_section" *ngIf="(topic.imageUrl || tmpImageUrl)">


### PR DESCRIPTION
Steps to test:
- create idea/discussion/vote topic
- add file > 5mb

Current:
- for idea is toast
- for discussion is label
- for vote there is nothing

Expected:
- show label for 3 topic types