### PR TITLE
Fix voting phase and step overflow [#1678]

### DIFF
--- a/src/app/topic/topic.component.html
+++ b/src/app/topic/topic.component.html
@@ -491,8 +491,10 @@
                   </div>
                 </ng-container>
               </div>
+
               <ng-container *ngIf="topic?.voteId && (vote$ | async) as vote">
                 <topic-vote-cast [ngClass]="(tabTablet === 'voting')? 'show': ''" [topic]="topic"
+                  [TourItem]="{tourid: 'topic', index: 7, position: 'top'}"
                   [vote]="vote"></topic-vote-cast>
               </ng-container>
             </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1239,7 +1239,7 @@ tour-item-template {
   transition: all 0.5s ease-in-out;
   gap: 16px;
   position: absolute;
-  width: 400px;
+  width: 560px;
   /* Shadow/Heavy */
   box-shadow: 0px 8px 20px 0px rgba(220, 231, 240, 0.3),
     0px 12px 16px 0px rgba(50, 85, 112, 0.1);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1293,6 +1293,8 @@ tour-item-template {
     justify-content: space-between;
     text-align: left;
     gap: 8px;
+    max-height: 300px;
+    overflow-y: auto;
 
     .title {
       font-size: 18px;


### PR DESCRIPTION
Steps to test:
- go to topic -> voting phase
- start onboarding

Current:
- 7th step still goes off the screen
- but if it's on the screen in right place, it goes off the top of the screen due to lots of text

Expected:
- 7th step on the right place
- it does not go off the screen