### PR TITLE
Add terms links to profile and help sidebar [#1797]

### DIFF
--- a/src/app/account/components/privacy-policy/privacy-policy.component.html
+++ b/src/app/account/components/privacy-policy/privacy-policy.component.html
@@ -39,19 +39,7 @@
     <div class="dialog_content">
       <div class="dialog_info_wrap">
         <div class="dialog_info">
-          <a class="info_row" target="_blank" [href]="config.termsOfUse">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M15 12V14L19 11.5L15 9V11H6V12H15Z" fill="#2C3B47" />
-            </svg>
-            <span translate="MODALS.PRIVACY_POLICY_LNK_TERMS_OF_USE"></span>
-          </a>
-          <a class="info_row" target="_blank" [href]="config.privacyPolicy">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M15 12V14L19 11.5L15 9V11H6V12H15Z" fill="#2C3B47" />
-            </svg>
-
-            <span translate="MODALS.PRIVACY_POLICY_LNK_PRIVACY_POLICY"></span>
-          </a>
+          <terms-links [withStatutLink]="false" />
         </div>
       </div>
     </div>

--- a/src/app/account/components/profile/profile.component.html
+++ b/src/app/account/components/profile/profile.component.html
@@ -184,6 +184,13 @@
               [model]="form.preferences?.showInSearch"
               (click)="form.preferences.showInSearch = !form.preferences.showInSearch"></cos-toggle>
           </div>
+
+          <div class="prefrence_box">
+            <div class="preference_title bold" translate="VIEWS.ACCOUNT.LBL_LINKS_TITLE"></div>
+            <div class="preference_description" translate="VIEWS.ACCOUNT.LBL_LINKS_DESCRIPTION"></div>
+            <terms-links />
+          </div>
+
           <div class="prefrence_box">
             <div class="preference_title bold" translate="VIEWS.ACCOUNT.LBL_DELETE_ACCOUNT"></div>
             <div class="preference_description" translate="VIEWS.ACCOUNT.LBL_DELETE_ACCOUNT_DESCRIPTION">

--- a/src/app/core/components/help/help.component.html
+++ b/src/app/core/components/help/help.component.html
@@ -20,6 +20,7 @@
       </svg>
     </button>
   </div>
+
   <div id="mobile_tour_info_wrap" *ngIf="showTourBox">
     <div class="title_wrap">
       <div>
@@ -38,6 +39,7 @@
     <div class="description" translate="HELP_WIDGET.EXTRA_INFO_TOUR_DESCRIPTION"></div>
     <button (click)="startTour()" class="start_btn" translate="HELP_WIDGET.EXTRA_INFO_TOUR_BTN_START"></button>
   </div>
+
   <div class="help_content">
     <form id="help_form" *ngIf="(app.showHelp| async)" [formGroup]="helpForm">
       <div class="help_form_text_wrap">
@@ -83,6 +85,11 @@
     </form>
     <!--frame id="help_frame" #helpFrame name="help_frame" *ngIf="(app.showHelp| async)" frameborder="0" [src]="urlSafe"
       width="100%"></!--frame-->
+  </div>
+
+  <div class="links_content">
+    <div class="bold links_content_title" translate="HELP_WIDGET.LINKS_TITLE"></div>
+    <terms-links />
   </div>
 </div>
 

--- a/src/app/core/components/help/help.component.scss
+++ b/src/app/core/components/help/help.component.scss
@@ -133,6 +133,8 @@
   border-radius: 4px;
   background: var(--color-surfaces);
   box-shadow: 0 0 8px 0 #727c84;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   @include mixins.mobile {
     width: 100%;
@@ -188,9 +190,19 @@
     }
   }
 
+  .links_content {
+    padding: 16px;
+    border-radius: 4px;
+    background: var(--color-background);
+    margin-top: 16px;
+
+    .links_content_title {
+      margin-bottom: 16px;
+    }
+  }
+
   .help_content {
     width: 400px;
-    height: 100vh;
 
     @include mixins.mobile {
       width: 100%;

--- a/src/app/shared/components/terms-links/terms-links.component.html
+++ b/src/app/shared/components/terms-links/terms-links.component.html
@@ -1,0 +1,10 @@
+<ul class="links_wrapper">
+  <li *ngFor="let link of links">
+    <a class="link" target="_blank" [href]="link.href">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 12V14L19 11.5L15 9V11H6V12H15Z" fill="#2C3B47" />
+      </svg>
+      <span [translate]="link.title"></span>
+    </a>
+  </li>
+</ul>

--- a/src/app/shared/components/terms-links/terms-links.component.scss
+++ b/src/app/shared/components/terms-links/terms-links.component.scss
@@ -1,0 +1,15 @@
+.links_wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 8px;
+
+  .link {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+}

--- a/src/app/shared/components/terms-links/terms-links.component.spec.ts
+++ b/src/app/shared/components/terms-links/terms-links.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TermsLinksComponent } from './terms-links.component';
+
+describe('TermsLinksComponent', () => {
+  let component: TermsLinksComponent;
+  let fixture: ComponentFixture<TermsLinksComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TermsLinksComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TermsLinksComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/terms-links/terms-links.component.ts
+++ b/src/app/shared/components/terms-links/terms-links.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { ConfigService } from '@services/config.service';
+
+interface ILink {
+  title: string;
+  href: string
+}
+
+@Component({
+  selector: 'terms-links',
+  templateUrl: './terms-links.component.html',
+  styleUrls: ['./terms-links.component.scss']
+})
+export class TermsLinksComponent {
+  @Input() withStatutLink?: boolean = true;
+
+  config: Record<string, unknown> & {
+    termsOfUse: string;
+    privacyPolicy: string;
+    statut: string;
+  };
+  links: ILink[] = []
+  constructor(ConfigService: ConfigService) {
+    this.config = ConfigService.get('legal');
+  }
+
+  ngOnInit() {
+    this.links = [
+      {
+        title: "MODALS.PRIVACY_POLICY_LNK_TERMS_OF_USE",
+        href: this.config.termsOfUse,
+      }, 
+      {
+        title: "MODALS.PRIVACY_POLICY_LNK_PRIVACY_POLICY",
+        href: this.config.privacyPolicy,
+      },
+      ...(this.withStatutLink ? [
+        {
+          title: "MODALS.PRIVACY_POLICY_LNK_ARTICLES_OF_ASSOCIATION",
+          href: this.config.statut,
+       }
+      ] : [])
+    ]
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -56,6 +56,7 @@ import { InterruptDialogComponent } from './components/interrupt-dialog/interrup
 import { TooltipComponent} from './components/tooltip/tooltip.component';
 import { ImageEditorComponent } from './components/image-editor/image-editor.component';
 import { SearchFilterComponent } from './components/search-filter/search-filter.component';
+import { TermsLinksComponent } from './components/terms-links/terms-links.component';
 import { TopicVoteDeadlineComponent } from '../topic/components/topic-vote-deadline/topic-vote-deadline.component';
 
 import { NotificationComponent } from '../core/components/notification/notification.component';
@@ -113,6 +114,7 @@ import { SiteNotificationComponent } from './components/site-notification/site-n
     TooltipComponent,
     ImageEditorComponent,
     SearchFilterComponent,
+    TermsLinksComponent,
     TopicVoteDeadlineComponent,
     NotificationComponent,
     MarkdownLinkDialogComponent,
@@ -181,6 +183,7 @@ import { SiteNotificationComponent } from './components/site-notification/site-n
     TooltipComponent,
     ImageEditorComponent,
     SearchFilterComponent,
+    TermsLinksComponent,
     DialogModule,
     NotificationComponent,
     MarkdownLinkDialogComponent,

--- a/src/assets/config/default.json
+++ b/src/assets/config/default.json
@@ -35,6 +35,7 @@
   "legal": {
     "termsOfUse": "https://citizenos.com/legal/api/",
     "privacyPolicy": "https://citizenos.com/legal/privacy/",
+    "statut": "https://citizenos.com/legal/statute/",
     "version": "1"
   },
   "attachments": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -88,7 +88,8 @@
     "MSG_REQUEST_SENT": "Your help request has been sent!",
     "EXTRA_INFO_TOUR_HEADING": "The page you’re on offers a walkthrough",
     "EXTRA_INFO_TOUR_DESCRIPTION": "The walkthrough will guide you through the main features and things to do on the page.",
-    "EXTRA_INFO_TOUR_BTN_START": "Start walkthrough"
+    "EXTRA_INFO_TOUR_BTN_START": "Start walkthrough",
+    "LINKS_TITLE": "Useful links"
   },
   "COMPONENTS": {
     "ACCESSIBILITY": {
@@ -1727,6 +1728,7 @@
     "PRIVACY_POLICY_DESCRIPTION_NEW_USER": "Thanks for creating an account! Before you continue, please take a moment to read and accept our Terms of Use and Privacy Policy",
     "PRIVACY_POLICY_LNK_TERMS_OF_USE": "Terms of use",
     "PRIVACY_POLICY_LNK_PRIVACY_POLICY": "Privacy Policy",
+    "PRIVACY_POLICY_LNK_ARTICLES_OF_ASSOCIATION": "Articles of Association",
     "PRIVACY_POLICY_BTN_REJECT": "Reject",
     "PRIVACY_POLICY_BTN_ACCEPT": "Accept",
     "USER_DELETE_CONFIRM_HEADING": "Delete account",
@@ -1982,6 +1984,8 @@
       "TAB_ACCOUNT": "Account",
       "LBL_SHOW_IN_SEARCH": "Show my username in search results",
       "LBL_SHOW_IN_SEARCH_DESCRIPTION": "Display my username in invite search results so that other people can easily invite me to groups and topics",
+      "LBL_LINKS_TITLE": "Links",
+      "LBL_LINKS_DESCRIPTION": "If necessary, you can consult our legal documentation.",
       "LBL_DELETE_ACCOUNT": "Delete your account",
       "LBL_DELETE_ACCOUNT_DESCRIPTION": "When deleting your account all your contributions will stay visible in Citizen OS, but they will not be linked to your account anymore.",
       "LBL_PROFILE_LANGUAEG": "Set your profile language",


### PR DESCRIPTION
Steps to test:
- go  to user profile
- go to help center

Current:
- no terms links

Expected:
- show terms links