### PR TITLE
Update group indicators, add ideations counter [#1656]

### DIFF
--- a/src/app/group/group.component.html
+++ b/src/app/group/group.component.html
@@ -353,7 +353,7 @@
               </div>
               <div class="info_number">{{group.members.topics.count.inProgress || 0}}</div>
             </div>
-            <!--div class="info_item">
+            <div class="info_item">
               <div>
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path fill-rule="evenodd" clip-rule="evenodd"
@@ -361,8 +361,8 @@
                     fill="#E4B722" />
                 </svg>
               </div>
-              <div class="info_number">1234</div>
-            </!--div-->
+              <div class="info_number">{{group.members.topics.count.ideation || 0}}</div>
+            </div>
             <div class="info_item">
               <div>
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Steps to test:
- go to any public group

Current:
- no ideations counter on top right panel

Expected:
- show ideations counter on top right panel