### PR TITLE
Fix: Missing translation in help center [#1797]

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -83,6 +83,7 @@
     "PLACEHOLDER_WRITE_YOUR_EMAIL": "Your email address (optional)",
     "PLACEHOLDER_WRITE_YOUR_MESSAGE": "Your message here...",
     "BTN_SEND": "Send",
+    "LINKS_TITLE": "Useful links",
     "ERROR_INVALID_EMAIL": "@:MSG_ERROR_POST_API_AUTH_SIGNUP_40000_EMAIL",
     "ERROR_INVALID_MESSAEG": "Message text is missing.",
     "MSG_REQUEST_SENT": "Your help request has been sent!",


### PR DESCRIPTION
Steps to test:
- go to help center

Current:
- missing translation for Useful links

Expected:
- correct translation for Useful links