### PR TITLE
Feature: Idea demographic fields [#1865]

### DIFF
--- a/src/app/ideation/components/add-idea/add-idea.component.html
+++ b/src/app/ideation/components/add-idea/add-idea.component.html
@@ -142,117 +142,44 @@
         </label>
       </cos-input>
 
-      <div *ngIf="ideation.allowAnonymous" class="anonymous_info">
+      <div
+        *ngIf="ideation.allowAnonymous && getDemographicKeys().length > 0"
+        class="anonymous_info"
+      >
         <cos-input
+          *ngFor="let key of getDemographicKeys()"
           placeholder="{{
             'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_AGE' | translate
           }}"
         >
           <input
-            id="demographics_age"
-            name="demographics_age"
-            formControlName="demographics_age"
+            [id]="'demographics_' + key"
+            [name]="'demographics_' + key"
+            [formControlName]="'demographics_' + key"
+            [(ngModel)]="ideation.demographicsConfig![key].value"
             autocomplete="off"
             placeholder="{{
-              'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_AGE' | translate
+              'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_' + key
+                | uppercase
+                | translate
             }}"
             class="gray_borders"
             [ngClass]="{
               error_input:
-                ideaForm.controls['demographics_age'].errors &&
-                ideaForm.controls['demographics_age'].errors['required'] &&
-                ideaForm.controls['demographics_age'].touched
+                ideaForm.controls['demographics_' + key].errors &&
+                ideaForm.controls['demographics_' + key].errors?.['required'] &&
+                ideaForm.controls['demographics_' + key].touched
             }"
-            type="number"
-            required
-            min="0"
+            [required]="ideation.demographicsConfig![key].required"
           />
 
           <label
-            for="demographics_age"
+            [for]="'demographics_' + key"
             class="error_label"
             *ngIf="
-              ideaForm.controls['demographics_age'].errors &&
-              ideaForm.controls['demographics_age'].errors['required'] &&
-              ideaForm.controls['demographics_age'].touched
-            "
-          >
-            <span
-              class="error_text"
-              translate="COMPONENTS.ADD_IDEA.FIELD_IS_MANDATORY"
-            ></span>
-          </label>
-        </cos-input>
-
-        <cos-input
-          placeholder="{{
-            'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_GENDER' | translate
-          }}"
-        >
-          <input
-            id="demographics_gender"
-            name="demographics_gender"
-            formControlName="demographics_gender"
-            autocomplete="off"
-            placeholder="{{
-              'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_GENDER' | translate
-            }}"
-            class="gray_borders"
-            [ngClass]="{
-              error_input:
-                ideaForm.controls['demographics_gender'].errors &&
-                ideaForm.controls['demographics_gender'].errors['required'] &&
-                ideaForm.controls['demographics_gender'].touched
-            }"
-            required
-          />
-          <label
-            for="demographics_gender"
-            class="error_label"
-            *ngIf="
-              ideaForm.controls['demographics_gender'].errors &&
-              ideaForm.controls['demographics_gender'].errors['required'] &&
-              ideaForm.controls['demographics_gender'].touched
-            "
-          >
-            <span
-              class="error_text"
-              translate="COMPONENTS.ADD_IDEA.FIELD_IS_MANDATORY"
-            ></span>
-          </label>
-        </cos-input>
-
-        <cos-input
-          placeholder="{{
-            'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_RESIDENCE' | translate
-          }}"
-        >
-          <input
-            id="demographics_residence"
-            name="demographics_residence"
-            formControlName="demographics_residence"
-            autocomplete="off"
-            placeholder="{{
-              'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_RESIDENCE' | translate
-            }}"
-            class="gray_borders"
-            [ngClass]="{
-              error_input:
-                ideaForm.controls['demographics_residence'].errors &&
-                ideaForm.controls['demographics_residence'].errors[
-                  'required'
-                ] &&
-                ideaForm.controls['demographics_residence'].touched
-            }"
-            required
-          />
-          <label
-            for="demographics_residence"
-            class="error_label"
-            *ngIf="
-              ideaForm.controls['demographics_residence'].errors &&
-              ideaForm.controls['demographics_residence'].errors['required'] &&
-              ideaForm.controls['demographics_residence'].touched
+              ideaForm.controls['demographics_' + key].errors &&
+              ideaForm.controls['demographics_' + key].errors?.['required'] &&
+              ideaForm.controls['demographics_' + key].touched
             "
           >
             <span

--- a/src/app/ideation/components/add-idea/add-idea.component.html
+++ b/src/app/ideation/components/add-idea/add-idea.component.html
@@ -149,7 +149,7 @@
         <cos-input
           *ngFor="let key of getDemographicKeys()"
           placeholder="{{
-            'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_AGE' | translate
+            'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_' + key | uppercase | translate
           }}"
         >
           <input

--- a/src/app/ideation/components/add-idea/add-idea.component.ts
+++ b/src/app/ideation/components/add-idea/add-idea.component.ts
@@ -172,6 +172,7 @@ export class AddIdeaComponent {
       description: this.ideaForm.value['description'],
       topicId: this.topicId,
       ideationId: this.ideation.id,
+      demographicsConfig: this.ideation.demographicsConfig,
     };
 
     this.TopicIdeaService.save(idea)
@@ -211,6 +212,10 @@ export class AddIdeaComponent {
     } else {
       this.saveIdea();
     }
+  }
+
+  getDemographicKeys() {
+    return Object.keys(this.ideation.demographicsConfig || {});
   }
 
   getIdeaIdWithVersion(ideaId: string, version: number) {

--- a/src/app/ideation/components/add-idea/add-idea.component.ts
+++ b/src/app/ideation/components/add-idea/add-idea.component.ts
@@ -30,6 +30,7 @@ import { Attachment } from '@interfaces/attachment';
 import { Ideation } from '@interfaces/ideation';
 import { DialogService } from '@shared/dialog';
 import { AnonymousDialogComponent } from '../anonymous-dialog/anonymous-dialog.component';
+import { Idea } from '@interfaces/idea';
 
 @Component({
   selector: 'add-idea',
@@ -165,17 +166,34 @@ export class AddIdeaComponent {
     });
   }
 
+  getDemographicValues(): Idea['demographics'] {
+    if (!this.ideation.demographicsConfig) {
+      return null;
+    }
+
+    return Object.keys(this.ideation.demographicsConfig)
+      .reduce((acc: Idea['demographics'], curr: string) => {
+        return {
+          ...acc,
+          [curr]: this.ideation.demographicsConfig?.[curr].value || '',
+        };
+      }, null);
+  }
+
   saveIdea() {
-    const idea = {
+    /**
+     * @todo Fix types for ideaData.
+     */
+    const ideaData: Partial<Idea> & {parentVersion: number; topicId: string} = {
       parentVersion: 0,
       statement: this.ideaForm.value['statement'],
       description: this.ideaForm.value['description'],
       topicId: this.topicId,
       ideationId: this.ideation.id,
-      demographicsConfig: this.ideation.demographicsConfig,
+      demographics: this.getDemographicValues(),
     };
 
-    this.TopicIdeaService.save(idea)
+    this.TopicIdeaService.save(ideaData)
       .pipe(take(1))
       .subscribe({
         next: (idea) => {

--- a/src/app/ideation/components/ideation-create/ideation-create.component.html
+++ b/src/app/ideation/components/ideation-create/ideation-create.component.html
@@ -1810,36 +1810,21 @@
                     class="anonymous_area_wrap"
                     [ngClass]="ideation.allowAnonymous ? '' : 'hidden'"
                   >
-                    <label class="checkbox">
+                    <label *ngFor="let key of demographicKeys" class="checkbox">
                       <span
                         [innerHTML]="
-                          'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_AGE'
+                          'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_' + key
+                            | uppercase
                             | translate
                         "
                       ></span>
-                      <input type="checkbox" name="orderBy" />
-                      <span class="checkmark"></span>
-                    </label>
-
-                    <label class="checkbox">
-                      <span
-                        [innerHTML]="
-                          'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_GENDER'
-                            | translate
-                        "
-                      ></span>
-                      <input type="checkbox" name="orderBy" />
-                      <span class="checkmark"></span>
-                    </label>
-
-                    <label class="checkbox">
-                      <span
-                        [innerHTML]="
-                          'VIEWS.IDEATION_CREATE.DEMOGRAPHICS_DATA_RESIDENCE'
-                            | translate
-                        "
-                      ></span>
-                      <input type="checkbox" name="orderBy" />
+                      <input
+                        type="checkbox"
+                        name="orderBy"
+                        [id]="key"
+                        [name]="key"
+                        [(ngModel)]="demographicsConfig[key].required"
+                      />
                       <span class="checkmark"></span>
                     </label>
                   </div>
@@ -1904,7 +1889,7 @@
                       [limit]="0"
                       name="idea_template"
                       id="idea_template"
-                      [item]="ideation.template"
+                      [item]="ideation.template || ''"
                       class="gray_borders"
                       (itemChange)="updateTemplate($event)"
                       placeholder="COMPONENTS.ADD_IDEA.PLACEHOLDER_EXPLAIN_YOUR_IDEA"

--- a/src/app/ideation/components/ideation-create/ideation-create.component.ts
+++ b/src/app/ideation/components/ideation-create/ideation-create.component.ts
@@ -95,15 +95,12 @@ export class IdeationCreateComponent
   demographicsConfig: NonNullable<Ideation['demographicsConfig']> = {
     age: {
       required: false,
-      value: '',
     },
     gender: {
       required: false,
-      value: '',
     },
     residence: {
       required: false,
-      value: '',
     },
   };
 

--- a/src/app/ideation/components/ideation-create/ideation-create.component.ts
+++ b/src/app/ideation/components/ideation-create/ideation-create.component.ts
@@ -24,6 +24,7 @@ import { BlockNavigationIfChange } from 'src/app/shared/pending-changes.guard';
 import { TopicDiscussionService } from '@services/topic-discussion.service';
 import { TopicSettingsDisabledDialogComponent } from 'src/app/topic/components/topic-settings-disabled-dialog/topic-settings-disabled-dialog.component';
 import { TopicSettingsLockedComponent } from 'src/app/topic/components/topic-settings-locked/topic-settings-locked.component';
+import { Ideation } from '@interfaces/ideation';
 
 @Component({
   selector: 'app-ideation-create',
@@ -91,19 +92,37 @@ export class IdeationCreateComponent
   languages$: { [key: string]: any } = this.config.get('language').list;
   topic$: Observable<Topic>;
 
+  demographicsConfig: NonNullable<Ideation['demographicsConfig']> = {
+    age: {
+      required: false,
+      value: '',
+    },
+    gender: {
+      required: false,
+      value: '',
+    },
+    residence: {
+      required: false,
+      value: '',
+    },
+  };
+
   /**/
   override tabs = ['info', 'settings', 'ideation_system', 'preview'];
   members = <any[]>[];
   enableTemplate = false;
-  public ideation = {
+  ideation: Ideation = {
     id: '',
     creatorId: '',
     question: '',
     deadline: null,
     disableReplies: false,
     allowAnonymous: false,
+    demographicsConfig: null,
     template: '',
+    // @ts-expect-error Fix later
     createdAt: '',
+    // @ts-expect-error Fix later
     updatedAt: '',
   };
   constructor(
@@ -276,6 +295,10 @@ export class IdeationCreateComponent
                     .subscribe({
                       next: (ideation) => {
                         this.ideation = ideation;
+                        console.log("test")
+                        if (ideation.demographicsConfig !== null) {
+                          this.demographicsConfig = ideation.demographicsConfig;
+                        }
                         this.ideation.question = this.ideation.question.trim();
                         if (this.ideation.deadline) {
                           this.deadline = new Date(this.ideation.deadline);
@@ -352,6 +375,21 @@ export class IdeationCreateComponent
         });
       }
     }
+  }
+
+  get demographicKeys() {
+    return Object.keys(this.demographicsConfig);
+  }
+
+  getDemographicEnabled() {
+    return Object.keys(this.demographicsConfig)
+      .filter((key) => this.demographicsConfig[key].required)
+      .reduce((acc: Ideation['demographicsConfig'], curr: string) => {
+        return {
+          ...acc,
+          [curr]: this.demographicsConfig[curr],
+        };
+      }, null);
   }
 
   createTopic() {
@@ -507,7 +545,11 @@ export class IdeationCreateComponent
   }
 
   createIdeation(updateTopicStatus?: boolean) {
-    const createIdeation: any = { topicId: this.topic.id, ...this.ideation };
+    const createIdeation = {
+      topicId: this.topic.id,
+      ...this.ideation,
+      demographicsConfig: this.getDemographicEnabled(),
+    };
     if (!this.deadlineSelect) {
       createIdeation.deadline = null;
     }
@@ -554,7 +596,6 @@ export class IdeationCreateComponent
         },
         error: (res) => {
           this.nextTab('ideation_system');
-          console.debug('createIdeation() ERR', res, res.errors);
           this.errors = res.errors;
           Object.values(this.errors).forEach((message) => {
             if (typeof message === 'string')
@@ -565,7 +606,11 @@ export class IdeationCreateComponent
   }
 
   updateIdeation(updateTopicStatus?: boolean) {
-    const updateIdeation = { topicId: this.topic.id, ...this.ideation };
+    const updateIdeation = {
+      topicId: this.topic.id,
+      ...this.ideation,
+      demographicsConfig: this.getDemographicEnabled(),
+    };
     if (!this.deadlineSelect) {
       updateIdeation.deadline = null;
     }
@@ -618,7 +663,6 @@ export class IdeationCreateComponent
   }
 
   removeChanges() {
-    console.log(this.topic);
     this.TopicService.revert(this.topic.id, this.topic.revision!)
       .pipe(take(1))
       .subscribe(() => {

--- a/src/app/ideation/components/ideation-create/ideation-create.component.ts
+++ b/src/app/ideation/components/ideation-create/ideation-create.component.ts
@@ -292,7 +292,6 @@ export class IdeationCreateComponent
                     .subscribe({
                       next: (ideation) => {
                         this.ideation = ideation;
-                        console.log("test")
                         if (ideation.demographicsConfig !== null) {
                           this.demographicsConfig = ideation.demographicsConfig;
                         }
@@ -379,6 +378,10 @@ export class IdeationCreateComponent
   }
 
   getDemographicEnabled() {
+    if (!this.ideation.allowAnonymous) {
+      return null;
+    }
+
     return Object.keys(this.demographicsConfig)
       .filter((key) => this.demographicsConfig[key].required)
       .reduce((acc: Ideation['demographicsConfig'], curr: string) => {

--- a/src/app/interfaces/idea.ts
+++ b/src/app/interfaces/idea.ts
@@ -6,6 +6,7 @@ export interface Idea {
   statement: string,
   description: string,
   imageUrl: string | null,
+  demographics: Record<string, string> | null,
   createdAt: string,
   updatedAt: string,
   deletedAt?: string | null,

--- a/src/app/interfaces/ideation.ts
+++ b/src/app/interfaces/ideation.ts
@@ -20,4 +20,5 @@ export interface Ideation {
   disableReplies: boolean;
   allowAnonymous: boolean;
   template: string | null;
+  demographicsConfig: Record<string, { required: boolean; value: string }> | null;
 }

--- a/src/app/interfaces/ideation.ts
+++ b/src/app/interfaces/ideation.ts
@@ -20,5 +20,5 @@ export interface Ideation {
   disableReplies: boolean;
   allowAnonymous: boolean;
   template: string | null;
-  demographicsConfig: Record<string, { required: boolean; value: string }> | null;
+  demographicsConfig: Record<string, { required: boolean; value?: string }> | null;
 }

--- a/src/app/services/activity.service.ts
+++ b/src/app/services/activity.service.ts
@@ -78,6 +78,15 @@ export class ActivityService extends ItemsListService {
             activity.data.origin.description = null;
           }
           const resultObject = Object.assign({}, activity.data.origin);
+
+          // diff cannot compare object states properly when
+          // previousValues was null and the field type is JSON.
+          // For example, for ideation/demigpaphics field:
+          // TypeError: Cannot use 'in' operator to search for 'age' in null
+          if (resultObject.demographicsConfig === null) {
+            resultObject.demographicsConfig = {};
+          }
+
           activity.data.resultObject = jsonpatch.applyPatch(resultObject, activity.data.result).newDocument;
           activity.data.result.forEach((item: any) => {
             const field = item.path.split('/')[1];

--- a/src/app/services/topic-ideation.service.ts
+++ b/src/app/services/topic-ideation.service.ts
@@ -78,9 +78,7 @@ export class TopicIdeationService extends ItemsListService {
   }
 
   update(data: any) {
-    console.log('data', data);
     const path = this.Location.getAbsoluteUrlApi(this.Auth.resolveAuthorizedPath('/topics/:topicId/ideations/:ideationId'), {topicId: data.topicId, ideationId: data.ideationId || data.id});
-    console.log(path);
     return this.http.put<ApiResponse>(path, data, { withCredentials: true, observe: 'body', responseType: 'json' })
       .pipe(
         map(res => res.data)


### PR DESCRIPTION
## Backend

BE configuration and data structure description - https://github.com/citizenos/citizenos-api/pull/399

## Description

Admins want to collect additional data when creating **anonymous** ideas. These are:
- age
- gender
- residence

More fields are possible in near future.

## Steps to test

- create idea
- go to settings tab and and enable posting anonymously
- then there are 3 options you can enable: age/gender/residence

After creating ideation, you are able to request these additional fields with posting new idea