### PR TITLE
Fix: Image scaling, remove empty image icon [#1905]

### DIFF
--- a/src/app/shared/components/invitation-dialog/invitation-dialog.component.html
+++ b/src/app/shared/components/invitation-dialog/invitation-dialog.component.html
@@ -56,29 +56,12 @@
 
     <div class="dialog_content dialog_content_join">
       <div class="content_row">
-        <div class="content_image_wrapper">
+        <div *ngIf="dialogData.imageUrl" class="content_image_wrapper">
           <img
-            *ngIf="dialogData.imageUrl"
             [src]="dialogData.imageUrl"
             class="content_image"
             [ngClass]="dialogData.view"
           />
-          <div class="no_image" *ngIf="!dialogData.imageUrl">
-            <svg
-              width="37"
-              height="41"
-              viewBox="0 0 37 41"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M29.307 5.5918C30.9953 5.5918 32.3766 7.08292 32.3766 8.90541V32.1007C32.3766 33.9232 30.9953 35.4143 29.307 35.4143H7.81962C6.13133 35.4143 4.75 33.9232 4.75 32.1007V8.90541C4.75 7.08292 6.13133 5.5918 7.81962 5.5918H29.307ZM17.0285 27.9752L13.1915 22.9882L7.81962 30.4439H29.307L22.4003 20.503L17.0285 27.9752Z"
-                fill="#4D5C6A"
-              />
-            </svg>
-          </div>
         </div>
 
         <div class="content_inner">

--- a/src/app/shared/components/invitation-dialog/invitation-dialog.component.scss
+++ b/src/app/shared/components/invitation-dialog/invitation-dialog.component.scss
@@ -20,7 +20,8 @@
 
 .content_image {
   width: 100%;
-  height: auto;
+  max-height: 260px;
+  aspect-ratio: 1;
   object-fit: cover;
 
   &.group {


### PR DESCRIPTION
Steps to test:
- test any invitation popup for topic/group

Current:
- some images are heigher that expected due to broken styles

Expected:
- fix image height