### PR TITLE
Fix: Markdown mobile styles [#1863]

### DIFF
--- a/src/app/directives/markdown.directive.ts
+++ b/src/app/directives/markdown.directive.ts
@@ -33,7 +33,7 @@ export class MarkdownDirective {
       {
         name: 'write',
         text: this.Translate.instant('MDEDITOR_TOOLTIP_WRITE'),
-        className: 'no-disable tab-active',
+        className: 'no-disable tab-active tab-action',
         action: (editor: any) => {
           if (editor.isPreviewActive()) {
             EasyMDE.togglePreview(editor);
@@ -44,7 +44,7 @@ export class MarkdownDirective {
       },
       {
         name: 'preview',
-        className: 'no-disable',
+        className: 'no-disable tab-action',
         text: this.Translate.instant('MDEDITOR_TOOLTIP_PREVIEW'),
         action: (editor: any) => {
           if (!editor.isPreviewActive()) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1838,13 +1838,24 @@ tour-item-template {
       margin-top: 0;
     }
 
+    .tab-action {
+      @include mixins.mobile {
+        width: 50% !important;
+      }
+    }
     .md-right {
       margin-top: 12px;
       float: right;
+      @include mixins.mobile {
+        float:none;
+      }
     }
     .separator {
       margin-top: 16px;
       float: right;
+      @include mixins.mobile {
+        float:none;
+      }
     }
     .write,
     .preview {


### PR DESCRIPTION
Steps to test:
- go to any md editor (mobile view)

Current:
- editor actions floated to right and a bit out of document flow

Expected:
- editor actions are below tabs