### PR TITLE
#1658

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,6 +37,10 @@ export class AppComponent {
   handleKeyUpEvent(event: KeyboardEvent) {
     if (this.keysPressed.indexOf(event.key) > -1) this.keysPressed.splice(this.keysPressed.indexOf(event.key), 1);
   }
+  @HostListener('window:popstate', ['$event'])
+  onPopState() {
+    this.dialog.closeAll();
+  }
 
   constructor(
     private readonly router: Router,


### PR DESCRIPTION
Close all open dialogs when browser back button is clicked.

As referenced in this issue https://github.com/citizenos/citizenos-fe/issues/1658
when user clicks back button while viewing an idea, the idea dialog stays open while the background view and URL changes.

Now all dialogs will be closed when back button is pressed