### PR TITLE
Fix: Protection data modal, enable empty description on draft [#1957, #1954]

### DIFF
--- a/src/app/ideation/components/add-idea/add-idea.component.html
+++ b/src/app/ideation/components/add-idea/add-idea.component.html
@@ -317,7 +317,7 @@
         </svg>
         <span translate="COMPONENTS.POST_ARGUMENT.BTN_ADD_IMAGE"></span>
       </button>
-      <button class="btn_medium_secondary icon" (click)="draftIdea()" [ngClass]="{disabled: ideaForm.invalid}">
+      <button class="btn_medium_secondary icon" (click)="draftIdea()" [ngClass]="{disabled: !availableForDraft}">
         <span class="btn_text" translate="COMPONENTS.ADD_IDEA.BTN_IDEA_DRAFT"></span>
       </button>
       <button class="btn_medium_submit icon" (click)="publishIdea()" [ngClass]="{disabled: ideaForm.invalid}">

--- a/src/app/ideation/components/add-idea/add-idea.component.ts
+++ b/src/app/ideation/components/add-idea/add-idea.component.ts
@@ -191,18 +191,25 @@ export class AddIdeaComponent {
     if (this.ideation.allowAnonymous) {
       let invitationDialog;
       if (status === IdeaStatus.draft) {
-        invitationDialog = this.dialog.open(AnonymousDraftDialogComponent);
+        const isDemographicsRequested = this.ideation.demographicsConfig && Object.values(this.ideation.demographicsConfig).some((config) => config.required);
+        if (isDemographicsRequested) {
+          invitationDialog = this.dialog.open(AnonymousDraftDialogComponent);
+        } else {
+          this.saveIdea(status);
+        }
       } else {
         invitationDialog = this.dialog.open(AnonymousDialogComponent);
       }
 
-      invitationDialog.afterClosed().subscribe({
-        next: (res) => {
-          if (res) {
-            this.saveIdea(status);
-          }
-        },
-      });
+      if (invitationDialog) {
+        invitationDialog.afterClosed().subscribe({
+          next: (res) => {
+            if (res) {
+              this.saveIdea(status);
+            }
+          },
+        });
+      }
     } else {
       this.saveIdea(status);
     }

--- a/src/app/ideation/components/edit-idea/edit-idea.component.html
+++ b/src/app/ideation/components/edit-idea/edit-idea.component.html
@@ -156,7 +156,7 @@
         </svg>
         <span translate="COMPONENTS.EDIT_IDEA.BTN_ADD_IMAGE"></span>
       </button>
-      <button class="btn_medium_secondary icon" (click)="draftIdea()" [ngClass]="{disabled: ideaForm.invalid}">
+      <button class="btn_medium_secondary icon" (click)="draftIdea()" [ngClass]="{disabled: !availableForDraft}">
         <span class="btn_text" translate="COMPONENTS.EDIT_IDEA.BTN_IDEA_DRAFT"></span>
       </button>
       <button class="btn_medium_submit icon" (click)="publishIdea()" [ngClass]="{disabled: ideaForm.invalid}">


### PR DESCRIPTION
Steps to test:
- start edit anon idea
- request for demographic fields

Current:
- no data protection dialog

Expected: 
- show dialog when demographic fields requested
- idea allows to be saved as draft with just a title
