### PR TITLE
fix: argument moderation paths to match the ones in the token

### DIFF
--- a/src/app/services/topic-argument.service.ts
+++ b/src/app/services/topic-argument.service.ts
@@ -154,7 +154,7 @@ export class TopicArgumentService extends ItemsListService {
   };
 
   moderate(data: any) {
-    const path = this.Location.getAbsoluteUrlApi('/api/topics/:topicId/discussions/:discussionId/comments/:commentId/reports/:reportId/moderate', data)
+    const path = this.Location.getAbsoluteUrlApi('/api/topics/:topicId/comments/:commentId/reports/:reportId/moderate', data)
     const headers = {
       'Authorization': 'Bearer ' + data.token
     };

--- a/src/app/topic/components/argument-report-moderate/argument-report-moderate.component.ts
+++ b/src/app/topic/components/argument-report-moderate/argument-report-moderate.component.ts
@@ -94,7 +94,8 @@ export class ArgumentReportModerateDialogComponent {
       take(1)
     ).subscribe({
       next: (report) => {
-        const reportDialog = dialog.open(ArgumentReportModerateComponent, { data: { report, topicId: this.topicId , commentId: this.commentId, token: this.token } });
+        console.log(report);
+        const reportDialog = dialog.open(ArgumentReportModerateComponent, { data: { report, topicId: this.topicId , discussionId: this.discussionId, commentId: this.commentId, token: this.token } });
         reportDialog.afterClosed().subscribe(() => {
           router.navigate(['topics', this.topicId]);
         })


### PR DESCRIPTION
Argument moderation path was without discussion and discussionId in the past and as I missed the fix during changing the whole concept of discussions the paths were not working. So quick-fix for now is to add the old paths back.